### PR TITLE
fix(eval): 放宽可重算评测补丁身份检查

### DIFF
--- a/src/opencollab_eval/commands/swe_v1_prolite_runner.py
+++ b/src/opencollab_eval/commands/swe_v1_prolite_runner.py
@@ -140,7 +140,10 @@ def main(*, prog: str | None = None, argv: Sequence[str] | None = None) -> int:
     parser.add_argument(
         "--expected-eval-patch-sha256",
         default="",
-        help="Required evaluation patch SHA-256 for an eval-only candidate",
+        help=(
+            "Optional evaluation patch SHA-256 assertion; the runner recomputes "
+            "the canonical value from the bound source patch"
+        ),
     )
     parser.add_argument("--eval-dir-name", default="official_eval", help="Official evaluation directory name")
     parser.add_argument("--parent-output-dir", type=Path, help="Bound parent run used by eval-only mode")
@@ -207,14 +210,19 @@ def main(*, prog: str | None = None, argv: Sequence[str] | None = None) -> int:
         r"[0-9a-f]{64}", args.expected_runtime_tree_sha256
     ):
         parser.error("--expected-runtime-tree-sha256 must be a lowercase SHA-256")
-    expected_candidate_fields = (
+    expected_candidate_binding = (
         args.expected_task,
         args.expected_record_id,
         args.expected_source_patch_sha256,
+    )
+    expected_candidate_fields = (
+        *expected_candidate_binding,
         args.expected_eval_patch_sha256,
     )
-    if any(expected_candidate_fields) and not all(expected_candidate_fields):
-        parser.error("eval-only candidate identity requires task, record ID, and both patch SHA-256 values")
+    if any(expected_candidate_fields) and not all(expected_candidate_binding):
+        parser.error(
+            "eval-only candidate identity requires task, record ID, and source patch SHA-256"
+        )
     if any(expected_candidate_fields) and not args.eval_only:
         parser.error("expected candidate identity is supported only with --eval-only")
     for option, value in (("--expected-task", args.expected_task), ("--expected-record-id", args.expected_record_id)):

--- a/src/opencollab_eval/engine/swe_v1_remote_evaluation.py
+++ b/src/opencollab_eval/engine/swe_v1_remote_evaluation.py
@@ -679,16 +679,16 @@ def main():
                 run_dir, task, eval_only=True
             )
             if done:
-                gen = eval_only_candidate_identity_error(gen := generation_done_result(
-                    task,
-                    prediction,
-                    metric,
-                    pairing,
-                    eval_only=True,
-                    artifact_identity_status=eval_only_generation_identity_status(
-                        prediction, metric, task
-                    ),
-                )) or gen
+                identity_status = eval_only_generation_identity_status(
+                    prediction, metric, task
+                )
+                gen = reconcile_eval_only_candidate_identity(
+                    generation_done_result(
+                        task, prediction, metric, pairing,
+                        eval_only=True,
+                        artifact_identity_status=identity_status,
+                    )
+                )
             else:
                 gen = {
                     "status": "skipped_no_generation_patch",

--- a/src/opencollab_eval/engine/swe_v1_remote_generation.py
+++ b/src/opencollab_eval/engine/swe_v1_remote_generation.py
@@ -519,7 +519,8 @@ def generation_for_task_once(row, *, reuse_existing_empty_patch=True):
     }
 
 
-def eval_only_candidate_identity_error(result):
+def reconcile_eval_only_candidate_identity(result):
+    """Keep immutable candidate bindings strict and derive the eval patch binding."""
     expected = {
         "task": expected_task,
         "record_id": expected_record_id,
@@ -527,22 +528,42 @@ def eval_only_candidate_identity_error(result):
         "eval_patch_sha256": expected_eval_patch_sha256,
     }
     if not any(expected.values()):
-        return None
+        return result
     observed = {
         "task": str(result.get("task") or ""),
         "record_id": str(result.get("record_id") or ""),
         "source_patch_sha256": str(result.get("source_patch_sha256") or result.get("patch_sha256") or ""),
         "eval_patch_sha256": str(result.get("eval_patch_sha256") or result.get("patch_sha256") or ""),
     }
-    if observed == expected:
-        return None
-    return {
-        "status": "candidate_identity_mismatch",
-        "task": result.get("task"),
-        "eval_only": True,
+    immutable_fields = ("task", "record_id", "source_patch_sha256")
+    mismatched = [
+        field for field in immutable_fields if observed[field] != expected[field]
+    ]
+    if mismatched:
+        return {
+            "status": "candidate_identity_mismatch",
+            "task": result.get("task"),
+            "eval_only": True,
+            "identity_mismatch_fields": mismatched,
+            "expected_candidate_identity": expected,
+            "observed_candidate_identity": observed,
+        }
+    eval_patch_matches = (
+        not expected["eval_patch_sha256"]
+        or observed["eval_patch_sha256"] == expected["eval_patch_sha256"]
+    )
+    if eval_patch_matches:
+        return result
+    reconciled = dict(result)
+    reconciled["artifact_identity_warnings"] = [
+        "stale_expected_eval_patch_sha256"
+    ]
+    reconciled["candidate_identity_reconciliation"] = {
+        "status": "accepted_recomputed_eval_patch",
         "expected_candidate_identity": expected,
         "observed_candidate_identity": observed,
     }
+    return reconciled
 
 
 def generation_for_task(row):

--- a/src/opencollab_eval/engine/swe_v1_remote_state.py
+++ b/src/opencollab_eval/engine/swe_v1_remote_state.py
@@ -353,9 +353,8 @@ def configure(config: dict[str, Any]) -> None:
         expected_task,
         expected_record_id,
         expected_source_patch_sha256,
-        expected_eval_patch_sha256,
     )
-    if any(expected_candidate_fields) and (
+    if any((*expected_candidate_fields, expected_eval_patch_sha256)) and (
         not eval_only
         or not all(expected_candidate_fields)
         or len(expected_task.encode("utf-8")) > 256
@@ -363,7 +362,10 @@ def configure(config: dict[str, Any]) -> None:
         or any(ord(character) < 32 for character in expected_task)
         or any(ord(character) < 32 for character in expected_record_id)
         or re.fullmatch(r"[0-9a-f]{64}", expected_source_patch_sha256) is None
-        or re.fullmatch(r"[0-9a-f]{64}", expected_eval_patch_sha256) is None
+        or (
+            expected_eval_patch_sha256
+            and re.fullmatch(r"[0-9a-f]{64}", expected_eval_patch_sha256) is None
+        )
     ):
         raise ValueError("invalid expected eval-only candidate identity")
     dry_run = bool(cfg["dry_run"])

--- a/tests/test_swe_v1_prolite_runner_evaluation_legacy.py
+++ b/tests/test_swe_v1_prolite_runner_evaluation_legacy.py
@@ -141,6 +141,10 @@ def test_remote_runner_eval_only_uses_existing_patch_without_starting_generation
         "max_task_starts": 1,
         "max_eval_attempts": 1,
         "eval_only": True,
+        "expected_task": task,
+        "expected_record_id": "existing",
+        "expected_source_patch_sha256": patch_sha,
+        "expected_eval_patch_sha256": "0" * 64,
         "eval_dir_name": "official_eval_fresh",
         "dry_run": False,
     }
@@ -170,6 +174,12 @@ def test_remote_runner_eval_only_uses_existing_patch_without_starting_generation
     assert summary["solver_attribution"] == "historical_artifact"
     assert summary["rows"][0]["generation"]["eval_only"] is True
     assert summary["rows"][0]["generation"]["artifact_identity_status"] == "legacy_unknown"
+    assert summary["rows"][0]["generation"]["artifact_identity_warnings"] == [
+        "stale_expected_eval_patch_sha256"
+    ]
+    assert summary["rows"][0]["generation"]["candidate_identity_reconciliation"][
+        "status"
+    ] == "accepted_recomputed_eval_patch"
     eval_dir = run_dir / "official_eval_fresh"
     assert eval_dir.stat().st_mode & 0o777 == 0o755
     assert (eval_dir / "input").stat().st_mode & 0o777 == 0o755

--- a/tests/test_swe_v1_prolite_runner_generation.py
+++ b/tests/test_swe_v1_prolite_runner_generation.py
@@ -308,7 +308,7 @@ def test_eval_only_rejects_legacy_candidate_interrupted_by_provider(tmp_path):
     assert result["status"] == "technical_generation_provider_evidence_invalid"
 
 
-def test_eval_only_rejects_candidate_identity_drift_before_evaluation(tmp_path):
+def test_eval_only_reconciles_derived_eval_patch_identity_before_evaluation(tmp_path):
     namespace = _remote_namespace(
         tmp_path,
         eval_only=True,
@@ -318,24 +318,27 @@ def test_eval_only_rejects_candidate_identity_drift_before_evaluation(tmp_path):
         expected_eval_patch_sha256="b" * 64,
     )
 
-    matching = namespace["eval_only_candidate_identity_error"](
+    matching = namespace["reconcile_eval_only_candidate_identity"](
         {
+            "status": "generation_done",
             "task": "task-1",
             "record_id": "r1",
             "source_patch_sha256": "a" * 64,
             "eval_patch_sha256": "b" * 64,
         }
     )
-    drifted = namespace["eval_only_candidate_identity_error"](
+    drifted = namespace["reconcile_eval_only_candidate_identity"](
         {
+            "status": "generation_done",
             "task": "task-1",
             "record_id": "r1",
             "source_patch_sha256": "a" * 64,
             "eval_patch_sha256": "c" * 64,
         }
     )
-    task_drifted = namespace["eval_only_candidate_identity_error"](
+    task_drifted = namespace["reconcile_eval_only_candidate_identity"](
         {
+            "status": "generation_done",
             "task": "task-2",
             "record_id": "r1",
             "source_patch_sha256": "a" * 64,
@@ -343,11 +346,54 @@ def test_eval_only_rejects_candidate_identity_drift_before_evaluation(tmp_path):
         }
     )
 
-    assert matching is None
-    assert drifted["status"] == "candidate_identity_mismatch"
-    assert drifted["observed_candidate_identity"]["eval_patch_sha256"] == "c" * 64
+    assert matching["status"] == "generation_done"
+    assert drifted["status"] == "generation_done"
+    assert drifted["artifact_identity_warnings"] == [
+        "stale_expected_eval_patch_sha256"
+    ]
+    assert drifted["candidate_identity_reconciliation"][
+        "observed_candidate_identity"
+    ]["eval_patch_sha256"] == "c" * 64
     assert task_drifted["status"] == "candidate_identity_mismatch"
+    assert task_drifted["identity_mismatch_fields"] == ["task"]
     assert task_drifted["observed_candidate_identity"]["task"] == "task-2"
+
+
+def test_eval_only_accepts_omitted_expected_eval_patch_identity(tmp_path):
+    namespace = _remote_namespace(
+        tmp_path,
+        eval_only=True,
+        expected_task="task-1",
+        expected_record_id="r1",
+        expected_source_patch_sha256="a" * 64,
+        expected_eval_patch_sha256="",
+    )
+
+    result = namespace["reconcile_eval_only_candidate_identity"](
+        {
+            "status": "generation_done",
+            "task": "task-1",
+            "record_id": "r1",
+            "source_patch_sha256": "a" * 64,
+            "eval_patch_sha256": "c" * 64,
+        }
+    )
+
+    assert result["status"] == "generation_done"
+    assert "artifact_identity_warnings" not in result
+
+
+def test_eval_only_without_manual_identity_assertion_keeps_candidate(tmp_path):
+    namespace = _remote_namespace(tmp_path, eval_only=True)
+    candidate = {
+        "status": "generation_done",
+        "task": "task-1",
+        "record_id": "r1",
+        "source_patch_sha256": "a" * 64,
+        "eval_patch_sha256": "c" * 64,
+    }
+
+    assert namespace["reconcile_eval_only_candidate_identity"](candidate) == candidate
 
 
 def _seed_remote_provider_failure(namespace, task, *, run_id=None, corrupt_snapshot=False):


### PR DESCRIPTION
## 改动

保留 eval-only 候选的题号、record ID 和完整源码补丁 SHA 强绑定。将预期 eval patch SHA 调整为可选断言，并从已绑定的源码补丁通过正式过滤逻辑重新计算实际 eval patch SHA。

旧的预期 eval patch SHA 与重算值不一致时，候选继续进入评测准备，并记录 `stale_expected_eval_patch_sha256` 警告。题号、record ID 或源码补丁 SHA 任一冲突时，仍返回 `candidate_identity_mismatch`。

## 原因

题 48 的测试文件会在 official eval 投影阶段被过滤。调用方误将 source patch SHA 同时作为 eval patch SHA，导致四项身份中的前三项完全一致时仍在 official eval 启动前退出。

## 验证

全库 Ruff 检查通过。完整 pytest 为 2651 passed 和 16 skipped。相关回归测试为 40 passed。

使用题 48 的真实历史候选执行零模型 dry-run，结果为 `generation_done=1`、`would_eval=1`、`technical_failed=0`、`eval_attempts=0`。错误的旧 eval SHA 被记录为警告，重算后的实际 SHA 继续绑定候选。独立 Reviewer 结论为 APPROVE。
