### PR TITLE
fix(eval): 修复 qutebrowser Qt 判分环境

### DIFF
--- a/src/opencollab_eval/engine/swe_v1_remote_pytest_controller.py
+++ b/src/opencollab_eval/engine/swe_v1_remote_pytest_controller.py
@@ -85,7 +85,7 @@ def _prepare_worker(repo):
     return home
 
 
-def _worker_environment(home, event_fd):
+def _worker_environment(home, event_fd, command):
     environment = {
         key: value
         for key, value in os.environ.items()
@@ -98,6 +98,10 @@ def _worker_environment(home, event_fd):
         PYTEST_ADDOPTS="-p no:cacheprovider",
         OPENCOLLAB_PYTEST_EVENT_FD=str(event_fd),
     )
+    # The qutebrowser adapter is the only plan that uses this launcher. Its
+    # Qt 6 images abort while constructing QApplication through the xcb path.
+    if command[:5] == ["xvfb-run", "-a", "python", "-m", "pytest"]:
+        environment["QT_QPA_PLATFORM"] = "offscreen"
     return environment
 
 
@@ -367,7 +371,7 @@ def main():
                 args.plugin_dir,
                 args.candidate_source_path,
             ),
-            env=_worker_environment(home, write_fd),
+            env=_worker_environment(home, write_fd, args.command),
             pass_fds=(write_fd,),
             close_fds=True,
             start_new_session=True,

--- a/tests/swe_v1_prolite_runner_adapter_pytest_tests.py
+++ b/tests/swe_v1_prolite_runner_adapter_pytest_tests.py
@@ -214,6 +214,36 @@ def test_controller_reserves_proof_before_candidate_execution(tmp_path):
         controller["_prepare_output"](proof, output)
 
 
+def test_controller_uses_offscreen_qt_for_xvfb_pytest(tmp_path, monkeypatch):
+    namespace = _remote_namespace(tmp_path)
+    controller = {"__name__": "controller_test"}
+    exec(namespace["prolite_pytest_controller_source"](), controller)
+    monkeypatch.setenv("QT_QPA_PLATFORM", "xcb")
+
+    environment = controller["_worker_environment"](
+        tmp_path,
+        7,
+        ["xvfb-run", "-a", "python", "-m", "pytest", "tests/test_widget.py"],
+    )
+
+    assert environment["QT_QPA_PLATFORM"] == "offscreen"
+
+
+def test_controller_preserves_qt_platform_for_regular_pytest(tmp_path, monkeypatch):
+    namespace = _remote_namespace(tmp_path)
+    controller = {"__name__": "controller_test"}
+    exec(namespace["prolite_pytest_controller_source"](), controller)
+    monkeypatch.setenv("QT_QPA_PLATFORM", "xcb")
+
+    environment = controller["_worker_environment"](
+        tmp_path,
+        7,
+        ["python", "-m", "pytest", "tests/test_widget.py"],
+    )
+
+    assert environment["QT_QPA_PLATFORM"] == "xcb"
+
+
 def test_controller_preserves_normal_skip_events(tmp_path):
     namespace = _remote_namespace(tmp_path)
     controller = {"__name__": "controller_test"}


### PR DESCRIPTION
## 变更

qutebrowser 的官方 pytest 计划通过 `xvfb-run -a python -m pytest` 启动时，受信任 worker 现在会把 `QT_QPA_PLATFORM` 固定为 `offscreen`。普通 pytest 计划继续保留已有 Qt 平台设置。

对应测试覆盖了 qutebrowser 专用命令的覆盖行为，也覆盖了普通 pytest 的兼容行为。

## 原因

两个不同 qutebrowser 镜像都在 pytest-qt 创建 `QApplication` 时以状态 86 中止。相同镜像与候选的对照实验确认默认 xcb 路径崩溃，offscreen 路径可以完整执行目标测试。容器身份、候选补丁和工作区证据均未发生变化。

## 验证

全库 Ruff 通过。完整测试结果为 2651 passed 和 16 skipped。新增相关测试共 39 项通过。新增文件检查和 `git diff --check` 通过。

真实 SWE-bench Pro-Lite 零模型恢复也已通过。第 64 题完成 7 个 fail-to-pass 与 154 个 pass-to-pass 目标，第 66 题完成 4 个 fail-to-pass 与 13 个 pass-to-pass 目标。两题均为 resolved，technical_failed 为零，候选摘要与镜像身份保持一致。
