### PR TITLE
fix: 修复 Jest 目标证据的前缀歧义

### DIFF
--- a/src/opencollab_eval/engine/swe_v1_remote_target_proof.py
+++ b/src/opencollab_eval/engine/swe_v1_remote_target_proof.py
@@ -581,44 +581,70 @@ def fail_to_pass_execution_proof(row, tests, exit_status, log_text):
                 else []
             )
             normalized = " ".join(str(fragment).split()) if not fragment_parts else ""
-            candidates = []
+
+            def file_candidates(candidates):
+                normalized_file = str(test_file or "").replace("\\", "/")
+                if not normalized_file:
+                    return candidates
+                return [
+                    item
+                    for item in candidates
+                    if (
+                        normalized_file
+                        == item.split(" | ", 1)[0].replace("\\", "/")
+                        or normalized_file.endswith(
+                            "/" + item.split(" | ", 1)[0].replace("\\", "/")
+                        )
+                        or item.split(" | ", 1)[0]
+                        .replace("\\", "/")
+                        .endswith("/" + normalized_file)
+                    )
+                ]
+
+            exact_candidates = []
+            abbreviated_candidates = []
             for item, title in expected_titles.items():
                 expected_title = " ".join(str(title).split())
-                if (
+                parts = expected_title_parts[item]
+                exact_part_match = bool(
                     fragment_parts
                     and (
-                        contiguous_title_parts_match(
-                            expected_title_parts[item],
-                            fragment_parts,
+                        any(
+                            parts
+                            == fragment_parts[offset : offset + len(parts)]
+                            for offset in range(len(fragment_parts) - len(parts) + 1)
                         )
                         or hierarchy_suffix_title_matches(
                             expected_title,
                             fragment_parts,
                         )
                     )
-                ) or (
+                )
+                exact_full_name_match = bool(
                     not fragment_parts
                     and (
                         expected_title == normalized
-                        or expected_title.endswith(" " + normalized)
                         or normalized.endswith(" " + expected_title)
                     )
+                )
+                if exact_part_match or exact_full_name_match:
+                    exact_candidates.append(item)
+                elif (
+                    fragment_parts
+                    and contiguous_title_parts_match(parts, fragment_parts)
+                ) or (
+                    not fragment_parts
+                    and expected_title.endswith(" " + normalized)
                 ):
-                    candidates.append(item)
-            normalized_file = str(test_file or "").replace("\\", "/")
-            if normalized_file:
-                file_candidates = []
-                for item in candidates:
-                    expected_file = item.split(" | ", 1)[0].replace("\\", "/")
-                    if (
-                        normalized_file == expected_file
-                        or normalized_file.endswith("/" + expected_file)
-                        or expected_file.endswith("/" + normalized_file)
-                    ):
-                        file_candidates.append(item)
-                candidates = file_candidates
-            if len(candidates) == 1:
-                return candidates[0]
+                    abbreviated_candidates.append(item)
+            exact_candidates = file_candidates(exact_candidates)
+            if len(exact_candidates) == 1:
+                return exact_candidates[0]
+            if exact_candidates:
+                return ""
+            abbreviated_candidates = file_candidates(abbreviated_candidates)
+            if len(abbreviated_candidates) == 1:
+                return abbreviated_candidates[0]
             return ""
 
         for line in text.splitlines():

--- a/tests/test_swe_v1_prolite_runner_target_js.py
+++ b/tests/test_swe_v1_prolite_runner_target_js.py
@@ -338,6 +338,39 @@ def test_jest_json_maps_unique_contiguous_abbreviated_titles():
     assert proof["missing"] == []
 
 
+def test_jest_json_prefers_exact_ancestor_titles_over_shorter_prefix_targets():
+    namespace = _proof_namespace()
+    test_file = "test/unit-tests/components/structures/RoomView-test.tsx"
+    variants = [
+        "and the current user adds a Jitsi widget after 10s",
+        "and the current user adds a Jitsi widget after two minutes",
+        "and the current user adds a Jitsi widget without timestamp",
+        "and the current user adds a Jitsi widget",
+    ]
+    expected = [
+        f"{test_file} | {variant} | should not remove the last widget"
+        for variant in variants
+    ]
+    ancestors = ["RoomView", "when there is a RoomView", "another user"]
+    assertions = [
+        {
+            "ancestorTitles": [*ancestors, variant],
+            "title": "should not remove the last widget",
+            "status": "passed",
+        }
+        for variant in variants
+    ]
+    event = {"testResults": [{"name": "/app/" + test_file, "assertionResults": assertions}]}
+    log = json.dumps(event)
+    proof = namespace["fail_to_pass_execution_proof"](
+        {"repo_language": "typescript", "repo": "element-hq/element-web"},
+        expected,
+        0,
+        log,
+    )
+    assert (proof["ok"], proof["passed"], proof["missing"]) == (True, expected, [])
+
+
 def test_jest_json_uses_ancestor_titles_to_disambiguate_duplicate_leaf_titles():
     namespace = _proof_namespace()
     test_file = "src/app/helpers/elements.test.ts"


### PR DESCRIPTION
同一测试文件内，Jest 目标共享叶标题且较短祖先标题是较长祖先标题前缀时，缩写匹配会产生多个候选并误报证据缺失。

改动让目标归属优先采用精确连续层级和精确层级后缀。只有没有精确候选时才回退到原有缩写匹配。新增回归覆盖四个共享叶标题的 RoomView 目标。

Ruff 全库检查通过。目标测试 24 项通过。完整 pytest 为 2650 项通过和 16 项跳过。真实第 72 题日志重放识别 234 个目标全部通过。独立审查结论为 APPROVE。