### PR TITLE
fix(eval): 修复 NodeBB 判分与重评预算

### DIFF
--- a/src/opencollab_eval/commands/swe_eval_layer_report.py
+++ b/src/opencollab_eval/commands/swe_eval_layer_report.py
@@ -407,7 +407,7 @@ def build_report(
     token_cost_path: Path | None = None,
     expected_indices: tuple[int, ...] | list[int] | None = None,
     max_rounds: int = 2,
-    max_eval_attempts: int = 2,
+    max_eval_attempts: int = 10,
     allow_over_budget_evidence: bool = False,
     usd_cny: float | None = None,
 ) -> dict[str, Any]:
@@ -773,7 +773,7 @@ def main() -> int:
     parser.add_argument("--expected-index", action="append", type=int, default=[])
     parser.add_argument("--token-cost-json", type=Path)
     parser.add_argument("--max-rounds", type=int, default=2)
-    parser.add_argument("--max-eval-attempts", type=int, default=2)
+    parser.add_argument("--max-eval-attempts", type=int, default=10)
     parser.add_argument("--allow-over-budget-evidence", action="store_true")
     parser.add_argument("--usd-cny", type=float)
     parser.add_argument("--json-output", type=Path, required=True)

--- a/src/opencollab_eval/commands/swe_rejudge_queue.py
+++ b/src/opencollab_eval/commands/swe_rejudge_queue.py
@@ -18,6 +18,7 @@ from typing import Any
 
 from opencollab_eval.commands import _swe_eval_layer_integrity, _swe_report_io
 from opencollab_eval.commands.swe_v1_parent_eval_lock import ParentEvalLock
+from opencollab_eval.commands.swe_v1_prolite_common import MAX_TOTAL_EVAL_ATTEMPTS
 from opencollab_eval.commands.swe_v1_prolite_controller import update_parent_fact_report
 from opencollab_eval.safe_files import write_regular_bytes_atomic
 
@@ -406,7 +407,7 @@ def _run_job(
             key,
             {"status": "skipped_terminal", "report": str(terminal), **job},
         )
-    if _observed_eval_attempts(job) >= 2:
+    if _observed_eval_attempts(job) >= MAX_TOTAL_EVAL_ATTEMPTS:
         return _set_job_state(
             state_path, state, key, {"status": "budget_exhausted", **job}
         )
@@ -457,7 +458,7 @@ def _run_job(
     if (
         result["status"] in {"command_failed", "technical_failed"}
         and launch_count < 2
-        and _observed_eval_attempts(job) < 2
+        and _observed_eval_attempts(job) < MAX_TOTAL_EVAL_ATTEMPTS
     ):
         return _run_job(
             plan,

--- a/src/opencollab_eval/commands/swe_v1_prolite_common.py
+++ b/src/opencollab_eval/commands/swe_v1_prolite_common.py
@@ -31,7 +31,7 @@ REMOTE_COMPLETION_MAX_CONSECUTIVE_PROBE_FAILURES = 3
 REMOTE_TERMINAL_STATUSES = frozenset(
     {"done", "done_with_technical_failures", "dry_run", "preflight_failed"}
 )
-MAX_TOTAL_EVAL_ATTEMPTS = 2
+MAX_TOTAL_EVAL_ATTEMPTS = 10
 ALLOWED_WORKFLOW_ENV_KEYS = frozenset(
     {
         "OPENCOLLAB_EVAL_REPOSITORY_MAP_BYTES",

--- a/src/opencollab_eval/commands/swe_v1_prolite_controller.py
+++ b/src/opencollab_eval/commands/swe_v1_prolite_controller.py
@@ -641,14 +641,14 @@ def apply_parent_eval_budget(args: argparse.Namespace) -> dict[str, Any] | None:
         counts_by_index.get(index, 0) + effective_additional_attempts
         for index in selected
     )
-    args.max_eval_attempts = projected_total_attempts
+    args.max_eval_attempts = effective_additional_attempts
     return {
         "max_total_eval_attempts": MAX_TOTAL_EVAL_ATTEMPTS,
         "previous_eval_attempts": counts_by_index,
         "final_report_eval_attempts": final_report_counts,
         "remaining_by_index": remaining_by_index,
         "effective_additional_eval_attempts": effective_additional_attempts,
-        "effective_max_eval_attempts": projected_total_attempts,
+        "effective_max_eval_attempts": effective_additional_attempts,
         "projected_total_eval_attempts": projected_total_attempts,
     }
 
@@ -665,7 +665,7 @@ def update_parent_fact_report(args: argparse.Namespace) -> dict[str, Any]:
         "--report-json",
         str(parent_summary),
         "--max-rounds",
-        "2",
+        str(MAX_TOTAL_EVAL_ATTEMPTS),
         "--allow-over-budget-evidence",
         "--json-output",
         str(parent_output_dir / "final_eval_layer_report.json"),

--- a/src/opencollab_eval/commands/swe_v1_prolite_report.py
+++ b/src/opencollab_eval/commands/swe_v1_prolite_report.py
@@ -54,9 +54,35 @@ def eval_only_reconciliation_reports(
 ) -> list[Path]:
     """Select cumulative execution evidence and the newest verdict per task."""
     candidates = set(parent_output_dir.glob("task_*_eval_only_*.json"))
+    final_report_path = parent_output_dir / "final_eval_layer_report.json"
+    try:
+        final_report_path.lstat()
+    except FileNotFoundError:
+        pass
+    else:
+        final_report, load_error = _swe_report_io.load_json_with_error(
+            final_report_path
+        )
+        if load_error:
+            raise RuntimeError(
+                f"prior final report is unavailable: {load_error}: {final_report_path}"
+            )
+        source_reports = final_report.get("source_reports")
+        if not isinstance(source_reports, list) or not source_reports or any(
+            not isinstance(value, str) or not value or not Path(value).is_absolute()
+            for value in source_reports
+        ):
+            raise RuntimeError(
+                f"prior final report has invalid source_reports: {final_report_path}"
+            )
+        parent_summary = (parent_output_dir / "parallel_summary.json").absolute()
+        for value in source_reports:
+            historical_path = Path(value).absolute()
+            if historical_path != parent_summary:
+                candidates.add(historical_path)
     candidates.add(current_report.absolute())
-    selected_execution: dict[int, tuple[tuple[int, int, str], Path]] = {}
-    selected_verdict: dict[int, tuple[tuple[int, int, str], Path]] = {}
+    selected_execution: set[Path] = set()
+    selected_verdict: dict[int, tuple[tuple[int, str], Path]] = {}
     for path in candidates:
         path = path.absolute()
         info = path.lstat()
@@ -69,24 +95,14 @@ def eval_only_reconciliation_reports(
         if len(rows) != 1 or len(indices) != 1:
             raise RuntimeError(f"eval-only report must contain one indexed row: {path}")
         index = next(iter(indices))
-        evaluation = rows[0].get("eval")
-        represented = (
-            evaluation.get("attempt_count") if isinstance(evaluation, dict) else 0
-        )
-        if isinstance(represented, bool) or not isinstance(represented, int):
-            represented = 0
-        verdict_score = (max(0, represented), info.st_mtime_ns, str(path))
+        verdict_score = (info.st_mtime_ns, str(path))
         if index not in selected_verdict or verdict_score > selected_verdict[index][0]:
             selected_verdict[index] = (verdict_score, path)
         executed = _integrity.eval_attempt_count(rows[0])
-        execution_score = (executed, info.st_mtime_ns, str(path))
-        if executed and (
-            index not in selected_execution
-            or execution_score > selected_execution[index][0]
-        ):
-            selected_execution[index] = (execution_score, path)
-    selected_paths = {
-        entry[1] for selected in (selected_execution, selected_verdict) for entry in selected.values()
+        if executed:
+            selected_execution.add(path)
+    selected_paths = selected_execution | {
+        entry[1] for entry in selected_verdict.values()
     }
     return sorted(selected_paths, key=str)
 

--- a/src/opencollab_eval/engine/swe_v1_remote_nodebb_mocha.py
+++ b/src/opencollab_eval/engine/swe_v1_remote_nodebb_mocha.py
@@ -1,0 +1,114 @@
+"""NodeBB Mocha title normalization and bound target-file launcher."""
+
+# ruff: noqa: E501
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import shlex
+
+_IMPORTED_SUITE_MARKER = re.compile(r"(?<!\S)test/[^\s:]+\.js::")
+
+
+def nodebb_mocha_runtime_title(title: object) -> str:
+    return " ".join(_IMPORTED_SUITE_MARKER.sub("", str(title)).split())
+
+
+def nodebb_mocha_selector_title(title: object) -> str:
+    return _IMPORTED_SUITE_MARKER.sub("", str(title))
+
+
+def nodebb_mocha_titles_are_unambiguous(tests: object) -> bool:
+    runtime_titles = [
+        nodebb_mocha_runtime_title(str(item).split(" | ", 1)[1])
+        for item in tests
+        if " | " in str(item)
+    ]
+    return bool(
+        all(runtime_titles)
+        and len(set(runtime_titles)) == len(runtime_titles)
+    )
+
+
+def nodebb_mocha_target_file_command(tests: object, target_file: str) -> str:
+    launcher = """import hashlib
+import json
+import pathlib
+import re
+import shutil
+import subprocess
+import sys
+
+tests = json.loads(open(sys.argv[1], encoding="utf-8").read())
+canonical_tests = json.dumps(tests, ensure_ascii=True, separators=(",", ":"))
+actual_targets_sha256 = hashlib.sha256(canonical_tests.encode("utf-8")).hexdigest()
+if actual_targets_sha256 != __OPENCOLLAB_EXPECTED_TARGETS_SHA256__:
+    print("Mocha target file does not match declared targets", file=sys.stderr)
+    raise SystemExit(127)
+imported_suite_marker = re.compile(__OPENCOLLAB_IMPORTED_SUITE_PATTERN__)
+grouped = {}
+runtime_titles = set()
+for value in tests:
+    item = str(value)
+    if " | " not in item:
+        continue
+    test_file, title = item.split(" | ", 1)
+    selector_title = imported_suite_marker.sub("", title)
+    normalized_title = " ".join(selector_title.split())
+    if not normalized_title or normalized_title in runtime_titles:
+        print("ambiguous NodeBB Mocha titles after import normalization", file=sys.stderr)
+        raise SystemExit(127)
+    runtime_titles.add(normalized_title)
+    grouped.setdefault(test_file, []).append(selector_title)
+if not grouped:
+    print("missing declared Mocha titles", file=sys.stderr)
+    raise SystemExit(127)
+status = 0
+for test_file in sorted(grouped):
+    selector = "^(?:" + "|".join(re.escape(title) for title in grouped[test_file]) + ")$"
+    if pathlib.Path("./node_modules/.bin/mocha").is_file():
+        command = ["./node_modules/.bin/mocha", "--timeout", "30000", "--reporter", "json-stream", "--grep", selector, test_file]
+    elif shutil.which("yarn"):
+        command = ["yarn", "test", "--timeout", "30000", "--reporter", "json-stream", "--grep", selector, test_file]
+    elif shutil.which("npx"):
+        command = ["npx", "mocha", "--timeout", "30000", "--reporter", "json-stream", "--grep", selector, test_file]
+    elif shutil.which("pnpm"):
+        command = ["pnpm", "test", "--", "--timeout", "30000", "--reporter", "json-stream", "--grep", selector, test_file]
+    elif shutil.which("corepack"):
+        command = ["corepack", "pnpm", "test", "--", "--timeout", "30000", "--reporter", "json-stream", "--grep", selector, test_file]
+    else:
+        print("No supported JS test runner found for mocha", file=sys.stderr)
+        raise SystemExit(127)
+    result = subprocess.run(command, text=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    print(result.stdout, end="")
+    if result.returncode != 0:
+        status = result.returncode
+raise SystemExit(status)
+""".replace(
+        "__OPENCOLLAB_IMPORTED_SUITE_PATTERN__",
+        repr(_IMPORTED_SUITE_MARKER.pattern),
+        1,
+    ).replace(
+        "__OPENCOLLAB_EXPECTED_TARGETS_SHA256__",
+        repr(
+            hashlib.sha256(
+                json.dumps(
+                    [str(item) for item in tests],
+                    ensure_ascii=True,
+                    separators=(",", ":"),
+                ).encode("utf-8")
+            ).hexdigest()
+        ),
+        1,
+    )
+    return "python3 -I -c " + shlex.quote(launcher) + " " + shlex.quote(target_file)
+
+
+__all__ = [
+    "nodebb_mocha_runtime_title",
+    "nodebb_mocha_selector_title",
+    "nodebb_mocha_target_file_command",
+    "nodebb_mocha_titles_are_unambiguous",
+]

--- a/src/opencollab_eval/engine/swe_v1_remote_target_proof.py
+++ b/src/opencollab_eval/engine/swe_v1_remote_target_proof.py
@@ -4,21 +4,17 @@
 
 from __future__ import annotations
 
-import hashlib
 import json
 import pathlib
 import re
 import shlex
 
-_NODEBB_IMPORTED_SUITE_MARKER = re.compile(r"(?<!\S)test/[^\s:]+\.js::")
-
-
-def _nodebb_mocha_runtime_title(title):
-    return " ".join(_NODEBB_IMPORTED_SUITE_MARKER.sub("", str(title)).split())
-
-
-def _nodebb_mocha_selector_title(title):
-    return _NODEBB_IMPORTED_SUITE_MARKER.sub("", str(title))
+from opencollab_eval.engine.swe_v1_remote_nodebb_mocha import (
+    nodebb_mocha_runtime_title,
+    nodebb_mocha_selector_title,
+    nodebb_mocha_target_file_command,
+    nodebb_mocha_titles_are_unambiguous,
+)
 
 
 def normalize_python_test_target(target):
@@ -207,85 +203,10 @@ def jest_test_command(test_files):
     return " &&\n".join(commands)
 
 def mocha_test_command(tests, selected, target_file=""):
-    runtime_titles = [
-        _nodebb_mocha_runtime_title(str(item).split(" | ", 1)[1])
-        for item in tests
-        if " | " in str(item)
-    ]
-    if any(not title for title in runtime_titles) or len(set(runtime_titles)) != len(runtime_titles):
+    if not nodebb_mocha_titles_are_unambiguous(tests):
         return ""
     if target_file:
-        launcher = """import hashlib
-import json
-import pathlib
-import re
-import shutil
-import subprocess
-import sys
-
-tests = json.loads(open(sys.argv[1], encoding="utf-8").read())
-canonical_tests = json.dumps(tests, ensure_ascii=True, separators=(",", ":"))
-actual_targets_sha256 = hashlib.sha256(canonical_tests.encode("utf-8")).hexdigest()
-if actual_targets_sha256 != __OPENCOLLAB_EXPECTED_TARGETS_SHA256__:
-    print("Mocha target file does not match declared targets", file=sys.stderr)
-    raise SystemExit(127)
-imported_suite_marker = re.compile(__OPENCOLLAB_IMPORTED_SUITE_PATTERN__)
-grouped = {}
-runtime_titles = set()
-for value in tests:
-    item = str(value)
-    if " | " not in item:
-        continue
-    test_file, title = item.split(" | ", 1)
-    selector_title = imported_suite_marker.sub("", title)
-    normalized_title = " ".join(selector_title.split())
-    if not normalized_title or normalized_title in runtime_titles:
-        print("ambiguous NodeBB Mocha titles after import normalization", file=sys.stderr)
-        raise SystemExit(127)
-    runtime_titles.add(normalized_title)
-    grouped.setdefault(test_file, []).append(selector_title)
-if not grouped:
-    print("missing declared Mocha titles", file=sys.stderr)
-    raise SystemExit(127)
-status = 0
-for test_file in sorted(grouped):
-    selector = "^(?:" + "|".join(re.escape(title) for title in grouped[test_file]) + ")$"
-    if pathlib.Path("./node_modules/.bin/mocha").is_file():
-        command = ["./node_modules/.bin/mocha", "--timeout", "30000", "--reporter", "json-stream", "--grep", selector, test_file]
-    elif shutil.which("yarn"):
-        command = ["yarn", "test", "--timeout", "30000", "--reporter", "json-stream", "--grep", selector, test_file]
-    elif shutil.which("npx"):
-        command = ["npx", "mocha", "--timeout", "30000", "--reporter", "json-stream", "--grep", selector, test_file]
-    elif shutil.which("pnpm"):
-        command = ["pnpm", "test", "--", "--timeout", "30000", "--reporter", "json-stream", "--grep", selector, test_file]
-    elif shutil.which("corepack"):
-        command = ["corepack", "pnpm", "test", "--", "--timeout", "30000", "--reporter", "json-stream", "--grep", selector, test_file]
-    else:
-        print("No supported JS test runner found for mocha", file=sys.stderr)
-        raise SystemExit(127)
-    result = subprocess.run(command, text=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-    print(result.stdout, end="")
-    if result.returncode != 0:
-        status = result.returncode
-raise SystemExit(status)
-""".replace(
-            "__OPENCOLLAB_IMPORTED_SUITE_PATTERN__",
-            repr(_NODEBB_IMPORTED_SUITE_MARKER.pattern),
-            1,
-        ).replace(
-            "__OPENCOLLAB_EXPECTED_TARGETS_SHA256__",
-            repr(
-                hashlib.sha256(
-                    json.dumps(
-                        [str(item) for item in tests],
-                        ensure_ascii=True,
-                        separators=(",", ":"),
-                    ).encode("utf-8")
-                ).hexdigest()
-            ),
-            1,
-        )
-        return "python3 -I -c " + shlex.quote(launcher) + " " + shlex.quote(target_file)
+        return nodebb_mocha_target_file_command(tests, target_file)
     files = canonical_js_test_files(tests, selected)
     requested_by_file = {}
     for item in tests:
@@ -298,7 +219,7 @@ raise SystemExit(status)
             if candidate == declared_file or candidate.endswith("/" + declared_file)
         ]
         resolved = max(matches, key=len) if matches else declared_file
-        requested_by_file.setdefault(resolved, []).append(_nodebb_mocha_selector_title(title))
+        requested_by_file.setdefault(resolved, []).append(nodebb_mocha_selector_title(title))
     commands = []
     for test_file in files:
         titles = requested_by_file.get(test_file) or []
@@ -555,7 +476,7 @@ def fail_to_pass_execution_proof(row, tests, exit_status, log_text):
         }
         if repo == "nodebb/nodebb":
             expected_titles = {
-                item: _nodebb_mocha_runtime_title(title)
+                item: nodebb_mocha_runtime_title(title)
                 for item, title in expected_titles.items()
             }
         expected_title_parts = {

--- a/src/opencollab_eval/engine/swe_v1_remote_target_proof.py
+++ b/src/opencollab_eval/engine/swe_v1_remote_target_proof.py
@@ -10,6 +10,16 @@ import pathlib
 import re
 import shlex
 
+_NODEBB_IMPORTED_SUITE_MARKER = re.compile(r"(?<!\S)test/[^\s:]+\.js::")
+
+
+def _nodebb_mocha_runtime_title(title):
+    return " ".join(_NODEBB_IMPORTED_SUITE_MARKER.sub("", str(title)).split())
+
+
+def _nodebb_mocha_selector_title(title):
+    return _NODEBB_IMPORTED_SUITE_MARKER.sub("", str(title))
+
 
 def normalize_python_test_target(target):
     target = str(target)
@@ -197,6 +207,13 @@ def jest_test_command(test_files):
     return " &&\n".join(commands)
 
 def mocha_test_command(tests, selected, target_file=""):
+    runtime_titles = [
+        _nodebb_mocha_runtime_title(str(item).split(" | ", 1)[1])
+        for item in tests
+        if " | " in str(item)
+    ]
+    if any(not title for title in runtime_titles) or len(set(runtime_titles)) != len(runtime_titles):
+        return ""
     if target_file:
         launcher = """import hashlib
 import json
@@ -212,13 +229,21 @@ actual_targets_sha256 = hashlib.sha256(canonical_tests.encode("utf-8")).hexdiges
 if actual_targets_sha256 != __OPENCOLLAB_EXPECTED_TARGETS_SHA256__:
     print("Mocha target file does not match declared targets", file=sys.stderr)
     raise SystemExit(127)
+imported_suite_marker = re.compile(__OPENCOLLAB_IMPORTED_SUITE_PATTERN__)
 grouped = {}
+runtime_titles = set()
 for value in tests:
     item = str(value)
     if " | " not in item:
         continue
     test_file, title = item.split(" | ", 1)
-    grouped.setdefault(test_file, []).append(title)
+    selector_title = imported_suite_marker.sub("", title)
+    normalized_title = " ".join(selector_title.split())
+    if not normalized_title or normalized_title in runtime_titles:
+        print("ambiguous NodeBB Mocha titles after import normalization", file=sys.stderr)
+        raise SystemExit(127)
+    runtime_titles.add(normalized_title)
+    grouped.setdefault(test_file, []).append(selector_title)
 if not grouped:
     print("missing declared Mocha titles", file=sys.stderr)
     raise SystemExit(127)
@@ -244,6 +269,10 @@ for test_file in sorted(grouped):
         status = result.returncode
 raise SystemExit(status)
 """.replace(
+            "__OPENCOLLAB_IMPORTED_SUITE_PATTERN__",
+            repr(_NODEBB_IMPORTED_SUITE_MARKER.pattern),
+            1,
+        ).replace(
             "__OPENCOLLAB_EXPECTED_TARGETS_SHA256__",
             repr(
                 hashlib.sha256(
@@ -269,7 +298,7 @@ raise SystemExit(status)
             if candidate == declared_file or candidate.endswith("/" + declared_file)
         ]
         resolved = max(matches, key=len) if matches else declared_file
-        requested_by_file.setdefault(resolved, []).append(title)
+        requested_by_file.setdefault(resolved, []).append(_nodebb_mocha_selector_title(title))
     commands = []
     for test_file in files:
         titles = requested_by_file.get(test_file) or []
@@ -524,8 +553,15 @@ def fail_to_pass_execution_proof(row, tests, exit_status, log_text):
             else item
             for item in expected
         }
+        if repo == "nodebb/nodebb":
+            expected_titles = {
+                item: _nodebb_mocha_runtime_title(title)
+                for item, title in expected_titles.items()
+            }
         expected_title_parts = {
-            item: [part.strip() for part in item.split(" | ")[1:] if part.strip()]
+            item: [expected_titles[item]]
+            if repo == "nodebb/nodebb"
+            else [part.strip() for part in item.split(" | ")[1:] if part.strip()]
             if " | " in item
             else [item]
             for item in expected

--- a/tests/test_nodebb_mocha_imported_titles.py
+++ b/tests/test_nodebb_mocha_imported_titles.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+from pathlib import Path
+
+from opencollab_eval.engine.swe_test_plan_contract import validated_test_plan_kind
+from opencollab_eval.engine.swe_v1_remote_target_proof import (
+    fail_to_pass_execution_proof,
+    mocha_test_command,
+)
+from opencollab_eval.engine.swe_v1_remote_test_plan import prolite_test_plan
+
+
+def _install_recording_mocha(tmp_path: Path) -> Path:
+    binary = tmp_path / "node_modules" / ".bin" / "mocha"
+    binary.parent.mkdir(parents=True)
+    binary.write_text(
+        "#!/usr/bin/env python3\n"
+        "import json, os, pathlib, sys\n"
+        "pathlib.Path(os.environ['MOCHA_CALLS']).write_text(json.dumps(sys.argv[1:]))\n"
+        "print('[\"end\",{\"tests\":2,\"passes\":2,\"failures\":0}]')\n",
+        encoding="utf-8",
+    )
+    binary.chmod(0o755)
+    return binary
+
+
+def test_nodebb_target_file_selector_removes_imported_suite_markers(tmp_path: Path):
+    _install_recording_mocha(tmp_path)
+    calls = tmp_path / "mocha-call.json"
+    target_file = tmp_path / "targets.json"
+    targets = [
+        "test/database.js | Test database test/database/sorted.js::Sorted Set methods "
+        "test/database/sorted.js::getSortedSetsMembers should return members with scores",
+        "test/database.js | Test database test/database/sorted.js::Sorted Set methods "
+        "test/database/sorted.js::getSortedSetsMembers should return multiple members with scores",
+    ]
+    target_file.write_text(json.dumps(targets), encoding="utf-8")
+
+    result = subprocess.run(
+        mocha_test_command(targets, ["test/database.js"], str(target_file)),
+        shell=True,
+        cwd=tmp_path,
+        env={**os.environ, "MOCHA_CALLS": str(calls)},
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    arguments = json.loads(calls.read_text(encoding="utf-8"))
+    selector = arguments[arguments.index("--grep") + 1]
+    assert re.fullmatch(
+        selector,
+        "Test database Sorted Set methods getSortedSetsMembers should return members with scores",
+    )
+    assert "test/database/sorted.js::" not in selector
+
+
+def test_nodebb_target_file_selector_preserves_significant_trailing_space(tmp_path: Path):
+    _install_recording_mocha(tmp_path)
+    calls = tmp_path / "mocha-call.json"
+    target_file = tmp_path / "targets.json"
+    target = (
+        "test/database.js | Test database test/database/sorted.js::Sorted Set methods "
+        "test/database/sorted.js::getSortedSetRange() should work with big arrays "
+        "(length > 100) "
+    )
+    target_file.write_text(json.dumps([target]), encoding="utf-8")
+
+    result = subprocess.run(
+        mocha_test_command([target], ["test/database.js"], str(target_file)),
+        shell=True,
+        cwd=tmp_path,
+        env={**os.environ, "MOCHA_CALLS": str(calls)},
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    arguments = json.loads(calls.read_text(encoding="utf-8"))
+    selector = arguments[arguments.index("--grep") + 1]
+    runtime_title = (
+        "Test database Sorted Set methods getSortedSetRange() should work with big arrays "
+        "(length > 100) "
+    )
+    assert re.fullmatch(selector, runtime_title)
+    assert re.fullmatch(selector, runtime_title.rstrip()) is None
+
+
+def test_nodebb_structured_proof_maps_runtime_titles_to_imported_targets():
+    expected = [
+        "test/database.js | Test database should work",
+        "test/database.js | Test database test/database/sorted.js::Sorted Set methods "
+        "test/database/sorted.js::getSortedSetsMembers should return members with scores",
+    ]
+    log = "\n".join(
+        [
+            '["pass",{"fullTitle":"Test database should work"}]',
+            '["pass",{"fullTitle":"Test database Sorted Set methods '
+            'getSortedSetsMembers should return members with scores"}]',
+        ]
+    )
+
+    proof = fail_to_pass_execution_proof(
+        {"repo_language": "js", "repo": "nodebb/nodebb"}, expected, 0, log
+    )
+
+    assert proof["ok"] is True
+    assert proof["observed"] == expected
+    assert proof["passed"] == expected
+    assert proof["missing"] == []
+
+
+def test_nodebb_import_normalization_collision_is_rejected():
+    targets = [
+        "test/database.js | Test database test/database/a.js::Suite should work",
+        "test/database.js | Test database test/database/b.js::Suite should work",
+    ]
+    plan = prolite_test_plan(
+        {
+            "repo_language": "js",
+            "repo": "nodebb/nodebb",
+            "selected_test_files_to_run": ["test/database.js"],
+        },
+        targets,
+        target_file="/eval_input/f2p.targets.json",
+    )
+
+    assert plan["commands"] == []
+    assert plan["coverage_verified"] is False
+    assert validated_test_plan_kind(plan, require_commands=True) is None
+    proof = fail_to_pass_execution_proof(
+        {"repo_language": "js", "repo": "nodebb/nodebb"},
+        targets,
+        0,
+        '["pass",{"fullTitle":"Test database Suite should work"}]',
+    )
+    assert proof["observed"] == []
+    assert proof["missing"] == targets

--- a/tests/test_swe_eval_layer_report.py
+++ b/tests/test_swe_eval_layer_report.py
@@ -392,7 +392,11 @@ def test_eval_layer_report_rejects_cross_run_third_eval_attempt(tmp_path):
     second_path = _write_json(tmp_path / "second.json", {"rows": [second]})
 
     try:
-        module.build_report([first_path, second_path], max_rounds=2)
+        module.build_report(
+            [first_path, second_path],
+            max_rounds=2,
+            max_eval_attempts=2,
+        )
     except ValueError as exc:
         assert "eval attempt budget exceeded" in str(exc)
         assert "task-a=3" in str(exc)
@@ -411,6 +415,7 @@ def test_eval_layer_report_preserves_over_budget_evidence_outside_final_result(t
     report = module.build_report(
         [first_path, second_path],
         max_rounds=2,
+        max_eval_attempts=2,
         allow_over_budget_evidence=True,
     )
 
@@ -424,6 +429,28 @@ def test_eval_layer_report_preserves_over_budget_evidence_outside_final_result(t
     assert task["accepted_eval_status"] == "technical_eval_failed"
     assert task["over_budget_evidence"][0]["eval_status"] == "eval_done"
     assert task["over_budget_evidence"][0]["resolved"] is False
+
+
+def test_eval_layer_report_default_accepts_ten_cross_run_eval_attempts(tmp_path):
+    module = _load_module()
+    paths = []
+    for index in range(10):
+        row = _row(
+            1,
+            "task-a",
+            f"/run-{index}/task-a.outer.log",
+            100,
+            "technical_eval_failed" if index < 9 else "eval_done",
+            False,
+        )
+        paths.append(_write_json(tmp_path / f"round-{index}.json", {"rows": [row]}))
+
+    report = module.build_report(paths, max_rounds=10)
+
+    assert report["max_eval_attempts"] == 10
+    assert report["counts"]["observed_eval_attempts"] == 10
+    assert report["counts"]["over_budget_tasks"] == 0
+    assert report["tasks"][0]["eval_attempt_count"] == 10
 
 
 def test_eval_layer_report_counts_cumulative_rejudge_ledger_once(tmp_path):

--- a/tests/test_swe_rejudge_queue.py
+++ b/tests/test_swe_rejudge_queue.py
@@ -277,10 +277,50 @@ def test_queue_runs_eval_only_with_generation_disabled(tmp_path, monkeypatch):
     assert argv[argv.index("--expected-record-id") + 1] == "record-25"
 
 
-def test_queue_skips_an_exhausted_candidate_without_starting_a_child(
+def test_queue_skips_a_ten_attempt_candidate_without_starting_a_child(
     tmp_path,
     monkeypatch,
 ):
+    plan, parent = _plan(tmp_path)
+    (parent / "parallel_summary.json").write_text(
+        json.dumps(
+            {
+                "results": [
+                    {
+                        "rows": [
+                            {
+                                "index": 25,
+                                "task": "instance_owner__repo-25",
+                                "generation": {
+                                    "record_id": "record-25",
+                                    "patch_sha256": "a" * 64,
+                                    "source_patch_sha256": "a" * 64,
+                                    "eval_patch_sha256": "a" * 64,
+                                },
+                                "eval": {
+                                    "status": "technical_eval_failed",
+                                    "attempt_count": 10,
+                                },
+                            }
+                        ]
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        queue,
+        "update_parent_fact_report",
+        lambda args: {"status": "done", "report_json": str(args.json_output)},
+    )
+    result = queue.run_queue(plan, tmp_path / "state", workers=2)
+
+    assert result["counts"] == {"budget_exhausted": 1}
+
+
+def test_queue_allows_recovery_after_two_prior_attempts(tmp_path, monkeypatch):
+    _accept_terminal(monkeypatch)
     plan, parent = _plan(tmp_path)
     (parent / "parallel_summary.json").write_text(
         json.dumps(
@@ -309,14 +349,23 @@ def test_queue_skips_an_exhausted_candidate_without_starting_a_child(
         ),
         encoding="utf-8",
     )
-    monkeypatch.setattr(
-        queue,
-        "update_parent_fact_report",
-        lambda args: {"status": "done", "report_json": str(args.json_output)},
-    )
-    result = queue.run_queue(plan, tmp_path / "state", workers=2)
+    calls = 0
 
-    assert result["counts"] == {"budget_exhausted": 1}
+    def fake_run(argv, *, stdout, stderr, text):
+        nonlocal calls
+        del stdout, stderr, text
+        calls += 1
+        json_output = Path(argv[argv.index("--json-output") + 1])
+        _terminal_report(json_output, index=25, patch_sha256="a" * 64, resolved=True)
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(queue.subprocess, "run", fake_run)
+    monkeypatch.setattr(queue, "update_parent_fact_report", lambda args: {})
+
+    result = queue.run_queue(plan, tmp_path / "state", workers=1)
+
+    assert calls == 1
+    assert result["counts"] == {"terminal": 1}
 
 
 @pytest.mark.parametrize(

--- a/tests/test_swe_v1_prolite_runner_parent_eval.py
+++ b/tests/test_swe_v1_prolite_runner_parent_eval.py
@@ -167,7 +167,160 @@ def test_eval_only_reconciliation_keeps_execution_and_derived_verdict(tmp_path):
     assert set(selected) == {executed, derived}
 
 
-def test_eval_only_parent_budget_allows_only_the_remaining_attempt(tmp_path):
+def test_eval_only_reconciliation_retains_prior_final_report_sources(tmp_path):
+    parent = tmp_path / "parent"
+    parent.mkdir()
+    task = "instance_owner__repo-82"
+    prior = tmp_path / "task_82_eval_only_prior.json"
+    prior.write_text(
+        json.dumps(
+            {
+                "rows": [
+                    {
+                        **_row(82, task, "/run/prior.log", 10, "technical_eval_failed"),
+                        "eval": {
+                            "status": "technical_eval_failed",
+                            "attempt_count": 2,
+                            "executed": True,
+                        },
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    (parent / "final_eval_layer_report.json").write_text(
+        json.dumps(
+            {
+                "source_reports": [
+                    str(parent / "parallel_summary.json"),
+                    str(prior),
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    current = tmp_path / "task_82_eval_only_current.json"
+    current.write_text(
+        json.dumps({"rows": [_row(82, task, "/run/current.log", 10, "eval_done", True)]}),
+        encoding="utf-8",
+    )
+
+    selected = runner.eval_only_reconciliation_reports(parent, current)
+
+    assert set(selected) == {prior, current}
+
+
+def test_eval_only_reconciliation_rejects_a_corrupt_prior_final_report(tmp_path):
+    parent = tmp_path / "parent"
+    parent.mkdir()
+    (parent / "final_eval_layer_report.json").write_text("{", encoding="utf-8")
+    current = tmp_path / "task_82_eval_only_current.json"
+    current.write_text(
+        json.dumps(
+            {
+                "rows": [
+                    _row(
+                        82,
+                        "instance_owner__repo-82",
+                        "/run/current.log",
+                        10,
+                        "eval_done",
+                        True,
+                    )
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(RuntimeError, match="invalid_report_json"):
+        runner.eval_only_reconciliation_reports(parent, current)
+
+
+@pytest.mark.parametrize("source_reports", [None, {}, [], ["relative.json"], [1]])
+def test_eval_only_reconciliation_rejects_invalid_historical_sources(
+    tmp_path,
+    source_reports,
+):
+    parent = tmp_path / "parent"
+    parent.mkdir()
+    (parent / "final_eval_layer_report.json").write_text(
+        json.dumps({"source_reports": source_reports}),
+        encoding="utf-8",
+    )
+    current = tmp_path / "task_82_eval_only_current.json"
+    current.write_text(
+        json.dumps(
+            {
+                "rows": [
+                    _row(
+                        82,
+                        "instance_owner__repo-82",
+                        "/run/current.log",
+                        10,
+                        "eval_done",
+                        True,
+                    )
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(RuntimeError, match="invalid source_reports"):
+        runner.eval_only_reconciliation_reports(parent, current)
+
+
+def test_eval_only_reconciliation_uses_recency_for_a_derived_verdict(tmp_path):
+    parent = tmp_path / "parent"
+    parent.mkdir()
+    task = "instance_owner__repo-82"
+    older = parent / "task_82_eval_only_old.json"
+    older.write_text(
+        json.dumps(
+            {
+                "rows": [
+                    {
+                        **_row(82, task, "/run/old.log", 10, "eval_done", False),
+                        "eval": {
+                            "status": "eval_done",
+                            "attempt_count": 2,
+                            "executed": False,
+                        },
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    newer = parent / "task_82_eval_only_new.json"
+    newer.write_text(
+        json.dumps(
+            {
+                "rows": [
+                    {
+                        **_row(82, task, "/run/new.log", 10, "eval_done", True),
+                        "eval": {
+                            "status": "eval_done",
+                            "attempt_count": 1,
+                            "executed": False,
+                        },
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    os.utime(older, ns=(1, 1))
+    os.utime(newer, ns=(2, 2))
+
+    selected = runner.eval_only_reconciliation_reports(parent, newer)
+
+    assert selected == [newer]
+
+
+def test_eval_only_parent_budget_keeps_the_current_run_limit_independent(tmp_path):
     parent = tmp_path / "parent"
     parent.mkdir()
     row = {
@@ -184,18 +337,19 @@ def test_eval_only_parent_budget_allows_only_the_remaining_attempt(tmp_path):
         parent_output_dir=parent,
         start_index=82,
         limit=1,
-        max_eval_attempts=2,
+        max_eval_attempts=1,
     )
 
     budget = runner.apply_parent_eval_budget(args)
 
     assert budget["effective_additional_eval_attempts"] == 1
-    assert budget["effective_max_eval_attempts"] == 2
+    assert budget["effective_max_eval_attempts"] == 1
     assert budget["projected_total_eval_attempts"] == 2
-    assert args.max_eval_attempts == 2
+    assert budget["max_total_eval_attempts"] == 10
+    assert args.max_eval_attempts == 1
 
 
-def test_eval_only_parent_budget_rejects_an_extra_retry(tmp_path):
+def test_eval_only_parent_budget_allows_recovery_after_two_prior_attempts(tmp_path):
     parent = tmp_path / "parent"
     parent.mkdir()
     row = {
@@ -215,12 +369,12 @@ def test_eval_only_parent_budget_rejects_an_extra_retry(tmp_path):
         max_eval_attempts=2,
     )
 
-    try:
-        runner.apply_parent_eval_budget(args)
-    except RuntimeError as exc:
-        assert "eval retry budget exhausted" in str(exc)
-    else:
-        raise AssertionError("an exhausted task must not launch another eval")
+    budget = runner.apply_parent_eval_budget(args)
+
+    assert budget["previous_eval_attempts"][82] == 2
+    assert budget["effective_additional_eval_attempts"] == 2
+    assert budget["projected_total_eval_attempts"] == 4
+    assert args.max_eval_attempts == 2
 
 
 def test_eval_only_parent_budget_uses_the_updated_final_report(tmp_path):
@@ -236,7 +390,7 @@ def test_eval_only_parent_budget_uses_the_updated_final_report(tmp_path):
         encoding="utf-8",
     )
     (parent / "final_eval_layer_report.json").write_text(
-        json.dumps({"tasks": [{"index": 82, "eval_attempt_count": 2}]}),
+        json.dumps({"tasks": [{"index": 82, "observed_eval_attempt_count": 9}]}),
         encoding="utf-8",
     )
     args = SimpleNamespace(
@@ -247,12 +401,12 @@ def test_eval_only_parent_budget_uses_the_updated_final_report(tmp_path):
         max_eval_attempts=2,
     )
 
-    try:
-        runner.apply_parent_eval_budget(args)
-    except RuntimeError as exc:
-        assert "eval retry budget exhausted" in str(exc)
-    else:
-        raise AssertionError("the updated parent report must block a third eval")
+    budget = runner.apply_parent_eval_budget(args)
+
+    assert budget["previous_eval_attempts"][82] == 9
+    assert budget["effective_additional_eval_attempts"] == 1
+    assert budget["projected_total_eval_attempts"] == 10
+    assert args.max_eval_attempts == 1
 
 
 def test_eval_only_parent_budget_adds_split_parent_attempts(tmp_path):
@@ -282,12 +436,36 @@ def test_eval_only_parent_budget_adds_split_parent_attempts(tmp_path):
         max_eval_attempts=2,
     )
 
-    try:
+    budget = runner.apply_parent_eval_budget(args)
+
+    assert budget["previous_eval_attempts"][82] == 2
+    assert budget["effective_additional_eval_attempts"] == 2
+    assert budget["projected_total_eval_attempts"] == 4
+    assert args.max_eval_attempts == 2
+
+
+def test_eval_only_parent_budget_rejects_after_ten_attempts(tmp_path):
+    parent = tmp_path / "parent"
+    parent.mkdir()
+    row = {
+        "index": 82,
+        "task": "instance_owner__repo-82",
+        "eval": {"status": "technical_eval_failed", "attempt_count": 10},
+    }
+    (parent / "parallel_summary.json").write_text(
+        json.dumps({"results": [{"rows": [row]}]}),
+        encoding="utf-8",
+    )
+    args = SimpleNamespace(
+        eval_only=True,
+        parent_output_dir=parent,
+        start_index=82,
+        limit=1,
+        max_eval_attempts=1,
+    )
+
+    with pytest.raises(RuntimeError, match="max total is 10"):
         runner.apply_parent_eval_budget(args)
-    except RuntimeError as exc:
-        assert "eval retry budget exhausted" in str(exc)
-    else:
-        raise AssertionError("split parent attempts must consume the full budget")
 
 
 def test_eval_only_parent_budget_does_not_count_a_dry_run(tmp_path):


### PR DESCRIPTION
## 改动说明

修复 NodeBB Mocha 导入套件标记进入测试标题后导致精确目标选择和结构化证据不一致的问题，并在归一化后拒绝歧义碰撞。

将累计 official eval 上限统一调整为十次，同时保持每个恢复运行的新增评测次数独立。历史评测报告会继续追溯已有来源，保留全部真实执行证据，并拒绝损坏或不完整的历史来源清单。

将 NodeBB 标题处理拆分为独立小模块，使全部 Python 文件继续满足八百行门禁。

## 验证结果

全库 Ruff 通过。最终完整 pytest 为 2684 项通过和 16 项跳过。相关回归、py_compile、diff check、新增文件门禁与独立 Reviewer 均通过。GitHub Actions 两套 Python 3.10、3.11、3.12 矩阵、两套 Deterministic SWE end-to-end、added-files、conventional-title 和 secrets 全部通过。
