### PR TITLE
fix(eval): 修复 Go 目标失败证明

### DIFF
--- a/src/opencollab_eval/engine/swe_v1_go_failure_proof.py
+++ b/src/opencollab_eval/engine/swe_v1_go_failure_proof.py
@@ -415,27 +415,19 @@ def _build_output_for_package(events: list[dict[str, Any]], package: str) -> str
     )
 
 
-def _target_timeout_matches(
-    proof: dict[str, Any],
+def _target_timeout_failure_packages(
     events: list[dict[str, Any]],
-    discoveries: list[dict[str, Any]],
-    declared_tests: list[str],
-    *,
-    expected_command: str,
-    observed_command: str,
-) -> bool:
-    if proof.get("dynamic_discovery") is True and (
-        not expected_command or expected_command != observed_command
-    ):
-        return False
-    bindings = _proof_bindings(proof, discoveries, declared_tests)
-    if not bindings or not _events_match_bindings(events, bindings):
-        return False
+    bindings: list[dict[str, Any]],
+) -> set[str]:
+    """Return packages with a strictly attributed target timeout."""
     failed_packages = {
         str(event.get("Package") or "")
         for event in events
-        if event.get("Action") == "fail" and event.get("Package")
+        if event.get("Action") == "fail"
+        and event.get("Package")
+        and not event.get("Test")
     }
+    proven: set[str] = set()
     for binding in bindings:
         matching_packages = [
             package
@@ -472,8 +464,59 @@ def _target_timeout_matches(
                 and event.get("Test") == test
             )
             if ran and actions.isdisjoint({"pass", "fail", "skip"}) and test in target_output:
-                return True
-    return False
+                proven.add(package)
+    return proven
+
+
+def _target_panic_failure_packages(
+    events: list[dict[str, Any]],
+    bindings: list[dict[str, Any]],
+) -> set[str]:
+    """Return packages with an unterminated declared target that emitted a panic."""
+    failed_packages = {
+        str(event.get("Package") or "")
+        for event in events
+        if event.get("Action") == "fail"
+        and event.get("Package")
+        and not event.get("Test")
+    }
+    proven: set[str] = set()
+    for binding in bindings:
+        matching_packages = [
+            package
+            for package in failed_packages
+            if _package_matches(binding["package"], package)
+        ]
+        if len(matching_packages) != 1:
+            continue
+        package = matching_packages[0]
+        for test in binding["tests"]:
+            target_events = [
+                event
+                for event in events
+                if event.get("Package") == package and event.get("Test") == test
+            ]
+            actions = {str(event.get("Action") or "") for event in target_events}
+            target_output = "".join(
+                str(event.get("Output") or "")
+                for event in target_events
+                if event.get("Action") == "output"
+            )
+            panic_lines = [
+                line.strip()
+                for line in target_output.splitlines()
+                if line.strip().startswith("panic: ")
+            ]
+            if (
+                "run" in actions
+                and actions.isdisjoint({"pass", "fail", "skip"})
+                and any(
+                    not line.startswith("panic: test timed out after ")
+                    for line in panic_lines
+                )
+            ):
+                proven.add(package)
+    return proven
 
 
 def go_pass_proof_matches(proof: dict[str, Any], log_text: str) -> bool:
@@ -541,50 +584,18 @@ def go_failure_proof_matches(
         for event in events
         if event.get("Action") == "fail" and event.get("Test") in expected
     ]
-    if exact_failures:
-        if plain_diagnostics or build_headers:
-            return False
-        if proof.get("dynamic_discovery") is not True:
-            if discoveries:
-                return False
-            if not proof.get("package"):
-                return True
-            bindings = _proof_bindings(proof, discoveries, declared_tests)
-            return bool(
-                bindings
-                and all(
-                    event.get("Package")
-                    and any(
-                        _package_matches(binding["package"], event["Package"])
-                        for binding in bindings
-                    )
-                    for event in exact_failures
-                )
-            )
-        bindings = _dynamic_bindings(discoveries, declared_tests)
-        return bool(
-            bindings
-            and _events_match_bindings(events, bindings)
-            and _dynamic_test_events_match_owners(events, bindings)
-        )
-    if _target_timeout_matches(
-        proof,
-        events,
-        discoveries,
-        declared_tests,
-        expected_command=expected_command,
-        observed_command=observed_command,
+    if (
+        exact_failures
+        and proof.get("dynamic_discovery") is not True
+        and not discoveries
+        and not proof.get("package")
     ):
-        return True
+        return not plain_diagnostics and not build_headers
     legacy_dynamic = _legacy_dynamic_command_matches(
         proof,
         expected_command,
         observed_command,
     )
-    if proof.get("dynamic_discovery") is True and (
-        not expected_command or expected_command != observed_command
-    ):
-        return False
     bindings = _proof_bindings(proof, discoveries, declared_tests)
     if not bindings:
         if not legacy_dynamic or discoveries:
@@ -592,11 +603,38 @@ def go_failure_proof_matches(
         bindings = []
     elif not _events_match_bindings(events, bindings):
         return False
+    exact_failure_packages: set[str] = set()
+    for event in exact_failures:
+        package = event.get("Package")
+        binding = _matching_binding(bindings, package) if isinstance(package, str) else None
+        if binding is None or event.get("Test") not in binding["tests"]:
+            return False
+        exact_failure_packages.add(package)
+    timeout_failure_packages = _target_timeout_failure_packages(events, bindings)
+    panic_failure_packages = _target_panic_failure_packages(events, bindings)
+    runtime_failure_packages = (
+        exact_failure_packages | timeout_failure_packages | panic_failure_packages
+    )
+    if (
+        proof.get("dynamic_discovery") is True
+        and runtime_failure_packages
+        and not _dynamic_test_events_match_owners(events, bindings)
+    ):
+        return False
     failed_packages = {
         str(event.get("Package") or "")
         for event in events
         if event.get("Action") == "fail" and event.get("Package")
     }
+    build_failed_packages = failed_packages - runtime_failure_packages
+    if proof.get("dynamic_discovery") is True and (
+        timeout_failure_packages
+        or panic_failure_packages
+        or build_failed_packages
+        or plain_diagnostics
+        or build_headers
+    ) and (not expected_command or expected_command != observed_command):
+        return False
     if plain_diagnostics and (
         not expected_command
         or expected_command != observed_command
@@ -604,11 +642,15 @@ def go_failure_proof_matches(
         return False
     if build_headers:
         unique_headers = set(build_headers)
-        if len(unique_headers) != len(failed_packages) or any(
+        if len(unique_headers) != len(build_failed_packages) or any(
             sum(_package_matches(failed_package, header) for header in unique_headers) != 1
-            for failed_package in failed_packages
+            for failed_package in build_failed_packages
         ) or any(
-            sum(_package_matches(failed_package, header) for failed_package in failed_packages) != 1
+            sum(
+                _package_matches(failed_package, header)
+                for failed_package in build_failed_packages
+            )
+            != 1
             for header in unique_headers
         ):
             return False
@@ -646,8 +688,11 @@ def go_failure_proof_matches(
                 for path in diagnostics
             )
         )
-    proven_packages = []
+    proven_packages = list(runtime_failure_packages)
     for failed_package in failed_packages:
+        if failed_package in runtime_failure_packages:
+            proven_packages.append(failed_package)
+            continue
         matching_bindings = [
             binding
             for binding in bindings
@@ -710,7 +755,8 @@ def go_failure_proof_matches(
         ):
             return False
         proven_packages.append(failed_package)
-    return bool(proven_packages)
+    expected_failure_packages = failed_packages | runtime_failure_packages
+    return bool(proven_packages) and set(proven_packages) == expected_failure_packages
 
 
 __all__ = [

--- a/tests/test_swe_v1_go_runtime_failure_composition.py
+++ b/tests/test_swe_v1_go_runtime_failure_composition.py
@@ -1,0 +1,207 @@
+"""Regression tests for composed and abrupt Go target failures."""
+
+from __future__ import annotations
+
+import json
+
+from opencollab_eval.engine.swe_v1_go_failure_proof import (
+    GO_TARGET_DISCOVERY_PREFIX,
+    go_failure_proof_matches,
+)
+
+
+def _discovery(package: str, test: str, test_file: str) -> str:
+    return GO_TARGET_DISCOVERY_PREFIX + json.dumps(
+        {"package": package, "tests": [test], "test_files": [test_file]},
+        sort_keys=True,
+    )
+
+
+def _event(**values: object) -> str:
+    return json.dumps(values, sort_keys=True)
+
+
+def _proof(*tests: str) -> dict[str, object]:
+    return {
+        "kind": "go_json_test_pass",
+        "tests": list(tests),
+        "dynamic_discovery": True,
+    }
+
+
+def _mixed_failure_log(*, diagnostic_path: str = "lib/ai/model/tokencount_test.go") -> str:
+    runtime_package = "example.invalid/project/lib/ai"
+    build_package = runtime_package + "/model"
+    return "\n".join(
+        (
+            _discovery("./lib/ai", "TestChatPromptTokens", "lib/ai/chat_test.go"),
+            _discovery(
+                "./lib/ai/model",
+                "TestTokenCount",
+                "lib/ai/model/tokencount_test.go",
+            ),
+            _event(Action="run", Package=runtime_package, Test="TestChatPromptTokens"),
+            _event(Action="fail", Package=runtime_package, Test="TestChatPromptTokens"),
+            _event(Action="fail", Package=runtime_package),
+            f"# {build_package}",
+            f"{diagnostic_path}:70:22: undefined: defaultTokenizer",
+            f"FAIL\t{build_package} [build failed]",
+        )
+    )
+
+
+def test_exact_failure_and_target_build_failure_compose_across_packages():
+    command = "exact discovery command"
+    proof = _proof("TestChatPromptTokens", "TestTokenCount")
+
+    assert go_failure_proof_matches(
+        proof,
+        _mixed_failure_log(),
+        expected_command=command,
+        observed_command=command,
+    )
+    assert not go_failure_proof_matches(
+        proof,
+        _mixed_failure_log(),
+        expected_command=command,
+        observed_command=command + " changed",
+    )
+    assert not go_failure_proof_matches(
+        proof,
+        _mixed_failure_log(diagnostic_path="lib/other/unrelated_test.go"),
+        expected_command=command,
+        observed_command=command,
+    )
+
+
+def _panic_log(
+    *,
+    target_output: bool = True,
+    terminal_action: str = "",
+    failed_package: str = "example.invalid/project/lib/kube/proxy",
+) -> str:
+    package = "example.invalid/project/lib/kube/proxy"
+    target = "TestMTLSClientCAs/1000_CAs"
+    panic_event: dict[str, object] = {
+        "Action": "output",
+        "Package": package,
+        "Output": "panic: runtime error: invalid memory address or nil pointer dereference\n",
+    }
+    if target_output:
+        panic_event["Test"] = target
+    lines = [
+        _discovery("./lib/kube/proxy", target, "lib/kube/proxy/server_test.go"),
+        _event(Action="run", Package=package, Test=target),
+        json.dumps(panic_event, sort_keys=True),
+        _event(
+            Action="output",
+            Package=package,
+            Test=target,
+            Output="example.invalid/project/lib/kube/proxy.(*forwarder).ServeHTTP()\n",
+        ),
+    ]
+    if terminal_action:
+        lines.append(_event(Action=terminal_action, Package=package, Test=target))
+    lines.append(_event(Action="fail", Package=failed_package))
+    return "\n".join(lines)
+
+
+def test_unterminated_target_attributed_panic_proves_package_failure():
+    command = "exact discovery command"
+    proof = _proof("TestMTLSClientCAs/1000_CAs")
+
+    assert go_failure_proof_matches(
+        proof,
+        _panic_log(),
+        expected_command=command,
+        observed_command=command,
+    )
+    assert not go_failure_proof_matches(
+        proof,
+        _panic_log(),
+        expected_command=command,
+        observed_command=command + " changed",
+    )
+
+
+def test_panic_requires_exact_target_attribution_and_unterminated_target():
+    command = "exact discovery command"
+    proof = _proof("TestMTLSClientCAs/1000_CAs")
+
+    for log in (
+        _panic_log(target_output=False),
+        _panic_log(terminal_action="pass"),
+        _panic_log(failed_package="example.invalid/project/lib/other"),
+        _panic_log().replace(
+            _event(Action="fail", Package="example.invalid/project/lib/kube/proxy"),
+            _event(
+                Action="fail",
+                Package="example.invalid/project/lib/kube/proxy",
+                Test="TestUnrelated",
+            ),
+        ),
+    ):
+        assert not go_failure_proof_matches(
+            proof,
+            log,
+            expected_command=command,
+            observed_command=command,
+        )
+
+
+def test_timeout_panic_is_excluded_from_abrupt_panic_proof():
+    command = "exact discovery command"
+    proof = _proof("TestMTLSClientCAs/1000_CAs")
+    log = _panic_log().replace(
+        "panic: runtime error: invalid memory address or nil pointer dereference",
+        "panic: test timed out after 10m0s",
+    )
+
+    assert not go_failure_proof_matches(
+        proof,
+        log,
+        expected_command=command,
+        observed_command=command,
+    )
+
+
+def test_target_timeout_does_not_hide_an_unproven_failed_package():
+    command = "exact discovery command"
+    timeout_package = "example.invalid/project/internal/server"
+    other_package = "example.invalid/project/internal/other"
+    timeout_target = "TestEvaluate"
+    log = "\n".join(
+        (
+            _discovery(
+                "./internal/server",
+                timeout_target,
+                "internal/server/evaluator_test.go",
+            ),
+            _discovery(
+                "./internal/other",
+                "TestOther",
+                "internal/other/other_test.go",
+            ),
+            _event(Action="run", Package=timeout_package, Test=timeout_target),
+            _event(
+                Action="output",
+                Package=timeout_package,
+                Output="panic: test timed out after 10m0s\n",
+            ),
+            _event(
+                Action="output",
+                Package=timeout_package,
+                Test=timeout_target,
+                Output="example.invalid/project/internal/server.TestEvaluate()\n",
+            ),
+            _event(Action="fail", Package=timeout_package),
+            _event(Action="fail", Package=other_package),
+        )
+    )
+
+    assert not go_failure_proof_matches(
+        _proof(timeout_target, "TestOther"),
+        log,
+        expected_command=command,
+        observed_command=command,
+    )


### PR DESCRIPTION
## 修复内容

Go official eval 同一批次可能同时出现目标测试运行失败与其他目标包编译失败。旧解析器看到 build header 后会直接拒绝已经存在的精确目标失败事件，使可信候选被记为技术失败。

目标测试发生 panic 时，`go test -json` 可能只产生目标 run 与 output 事件，随后由 package fail 结束，没有标准 Test fail 事件。旧解析器只能证明 timeout，不能证明严格归属到目标测试的 panic。

本次修改按失败 package 组合 exact、timeout、panic 和 build 证明。每个失败 package 都必须得到唯一、完整且命令一致的因果绑定。目标 panic 还要求目标 run 已发生、panic output 明确归属同一目标、目标没有 pass、fail 或 skip 终态，并且 package 以非零状态失败。

## 验证

全库 Ruff 通过。

聚焦回归 131 项通过。

完整 pytest 为 2689 passed、16 skipped。

SWE-bench Pro-Lite 题 97 和 99 的 immutable official 日志重放均为 matched=true，命令身份一致。

生产模块 766 行，新测试文件 207 行，diff check 与文件卫生通过。

独立 Reviewer 已明确 APPROVE。

此 PR 保持 Draft，等待人工审阅。
