### PR TITLE
fix(eval): 严格校验阻塞候选的补评身份

### DIFF
--- a/src/opencollab_eval/commands/swe_v1_prolite_runner.py
+++ b/src/opencollab_eval/commands/swe_v1_prolite_runner.py
@@ -193,6 +193,8 @@ def main(*, prog: str | None = None, argv: Sequence[str] | None = None) -> int:
         parser.error("--eval-only requires --parent-output-dir")
     if args.eval_only and args.limit != 1:
         parser.error("--eval-only requires --limit 1")
+    if args.eval_only and args.max_task_starts != 0:
+        parser.error("--eval-only requires --max-task-starts 0")
 
     if args.start_index < 1:
         parser.error("--start-index must be >= 1")

--- a/src/opencollab_eval/engine/swe_v1_remote_eval_candidate.py
+++ b/src/opencollab_eval/engine/swe_v1_remote_eval_candidate.py
@@ -11,6 +11,7 @@ from opencollab_eval.engine.swe_v1_remote_records import (
     generation_done,
     historical_generation_identity_status,
     latest_pair,
+    read_jsonl,
 )
 
 _BLOCKED_IDENTITY_FIELDS = (
@@ -30,6 +31,17 @@ _BLOCKED_IDENTITY_FIELDS = (
     "wire_protocol",
     "reasoning_effort",
 )
+_BLOCKED_CAUSAL_FIELDS = (
+    "workflow_status",
+    "runner_returncode",
+    "runtime_status",
+    "error",
+    "submission_eligible",
+    "execution_quiesced",
+    "container_execution_quiesced",
+    "workflow_result",
+)
+_EXECUTION_ABORT_MARKER = "Execution environment has been aborted"
 
 
 def _positive_integer(value):
@@ -104,6 +116,41 @@ def _agent_failure_evidence_valid(value):
     return summarize_terminal_provider_failures(value) is None
 
 
+def _blocked_technical_interruption_proven(metric, matching_official_eval_attempts):
+    if matching_official_eval_attempts != 0:
+        return False
+    if (
+        metric.get("runner_returncode") != 1
+        or metric.get("runtime_status") != "completed"
+        or metric.get("error") not in (None, "")
+        or metric.get("submission_eligible") is not True
+        or metric.get("execution_quiesced") is not True
+        or metric.get("container_execution_quiesced") is not True
+    ):
+        return False
+    result = metric.get("workflow_result")
+    if not isinstance(result, dict) or result.get("status") != "blocked":
+        return False
+    blocker = result.get("blocker")
+    attempts = result.get("attempts")
+    if not isinstance(blocker, str) or _EXECUTION_ABORT_MARKER not in blocker:
+        return False
+    if not isinstance(attempts, list) or not attempts or not isinstance(attempts[-1], dict):
+        return False
+    verdict = attempts[-1].get("final_verdict")
+    return bool(
+        isinstance(verdict, dict) and verdict.get("verdict") == "BLOCKED" and verdict.get("findings") == blocker
+    )
+
+
+def _matching_official_eval_attempt_count(run_dir, task):
+    return sum(
+        1
+        for row in read_jsonl(run_dir / "eval_attempts.jsonl")
+        if row.get("phase") == "eval_attempt_started" and row.get("task") == task
+    )
+
+
 def _blocked_identity_document_proven(prediction, metric):
     if not isinstance(prediction, dict) or not isinstance(metric, dict):
         return False
@@ -126,6 +173,10 @@ def _blocked_identity_document_proven(prediction, metric):
     if any(field not in embedded or field not in metric for field in _BLOCKED_IDENTITY_FIELDS):
         return False
     if any(embedded[field] != metric[field] for field in _BLOCKED_IDENTITY_FIELDS):
+        return False
+    if any(field not in embedded or field not in metric for field in _BLOCKED_CAUSAL_FIELDS):
+        return False
+    if any(embedded[field] != metric[field] for field in _BLOCKED_CAUSAL_FIELDS):
         return False
     if _normalized_historical_llm_transport(embedded, metric) is None:
         return False
@@ -163,7 +214,13 @@ def _blocked_identity_document_proven(prediction, metric):
     )
 
 
-def eval_only_generation_identity_status(prediction, metric, task):
+def eval_only_generation_identity_status(
+    prediction,
+    metric,
+    task,
+    *,
+    matching_official_eval_attempts,
+):
     identity_metric = metric
     if (
         isinstance(metric, dict)
@@ -174,12 +231,19 @@ def eval_only_generation_identity_status(prediction, metric, task):
         agent_failures = metric.get("agent_failures")
         if not _agent_failure_evidence_valid(agent_failures):
             return "invalid"
+        if not _blocked_technical_interruption_proven(
+            metric,
+            matching_official_eval_attempts,
+        ):
+            return "invalid"
         identity_metric = dict(metric)
         identity_metric.pop("provider_failure", None)
         # A blocked workflow can retain an agent-stage failure after producing a
         # complete, quiesced candidate.  The eval-only gate proves that candidate
         # independently, while the original failure evidence remains untouched.
         identity_metric["agent_failures"] = []
+        status = historical_generation_identity_status(prediction, identity_metric, task)
+        return "blocked_technical_verified" if status == "verified" else "invalid"
     return historical_generation_identity_status(prediction, identity_metric, task)
 
 
@@ -187,5 +251,13 @@ def generation_done_for_mode(run_dir, task, *, eval_only):
     if not eval_only:
         return generation_done(run_dir, task, require_identity=True)
     prediction, metric, pairing = latest_pair(run_dir, task)
-    status = eval_only_generation_identity_status(prediction, metric, task)
+    status = eval_only_generation_identity_status(
+        prediction,
+        metric,
+        task,
+        matching_official_eval_attempts=_matching_official_eval_attempt_count(
+            run_dir,
+            task,
+        ),
+    )
     return status != "invalid", prediction, metric, pairing

--- a/src/opencollab_eval/engine/swe_v1_remote_eval_candidate.py
+++ b/src/opencollab_eval/engine/swe_v1_remote_eval_candidate.py
@@ -2,15 +2,22 @@
 
 from __future__ import annotations
 
+import hashlib
+import json
 import math
+import os
 import re
+from pathlib import Path
 
 from opencollab_eval.engine.provider_failures import summarize_terminal_provider_failures
+from opencollab_eval.engine.swe_eval_records import open_regular_binary
+from opencollab_eval.engine.swe_generation_proof import current_generation_proof_valid
 from opencollab_eval.engine.swe_v1_remote_records import (
     embedded_workflow_metric,
     generation_done,
     historical_generation_identity_status,
     latest_pair,
+    prediction_patch,
     read_jsonl,
 )
 
@@ -42,6 +49,22 @@ _BLOCKED_CAUSAL_FIELDS = (
     "workflow_result",
 )
 _EXECUTION_ABORT_MARKER = "Execution environment has been aborted"
+_MAX_TRAJECTORY_BYTES = 16 * 1024 * 1024
+_MAX_TRAJECTORY_LINE_BYTES = 2 * 1024 * 1024
+_MAX_TRAJECTORY_ROWS = 10_000
+_GO_PROBE_RE = re.compile(r"(?:^|[;&|]\s*)go\s+(?:build|test)\b")
+_CORRECTED_GO_PROBE_RE = re.compile(
+    r"\Aexport\s+PATH=\$PATH:/usr/local/go/bin\s*&&\s*"
+    r"cd\s+/testbed\s*&&\s*(?:go\s+version\s*&&\s*)?"
+    r"go\s+(?:build|test)\b(?P<tail>.*)\Z",
+    re.DOTALL,
+)
+_UNCORRECTED_GO_PROBE_RE = re.compile(
+    r"\Acd\s+/testbed\s*&&\s*go\s+(?:build|test)\b(?P<tail>.*)\Z",
+    re.DOTALL,
+)
+_GO_DIAGNOSTIC_RE = re.compile(r"^(?P<path>[^:\n]+\.go):\d+:\d+:\s+(?P<detail>.+)$")
+_TOOL_EXIT_RE = re.compile(r"\AExit code:\s*(?P<code>\d+)\s*(?:\n|\Z)")
 
 
 def _positive_integer(value):
@@ -143,6 +166,258 @@ def _blocked_technical_interruption_proven(metric, matching_official_eval_attemp
     )
 
 
+def _bounded_verified_trajectory(metric):
+    path_text = metric.get("trajectory_path")
+    expected_sha = metric.get("trajectory_sha256")
+    instance_id = metric.get("instance_id")
+    if (
+        not isinstance(path_text, str)
+        or not path_text
+        or not isinstance(expected_sha, str)
+        or re.fullmatch(r"[0-9a-f]{64}", expected_sha) is None
+        or not isinstance(instance_id, str)
+        or not instance_id
+    ):
+        return None
+    path = Path(path_text)
+    if (
+        not path.is_absolute()
+        or path.name != "orchestration.jsonl"
+        or instance_id not in path.parts
+        or ".." in path.parts
+    ):
+        return None
+    try:
+        if path.resolve(strict=True) != path:
+            return None
+        with open_regular_binary(path) as handle:
+            opened = os.fstat(handle.fileno())
+            if opened.st_size > _MAX_TRAJECTORY_BYTES:
+                return None
+            raw = handle.read(_MAX_TRAJECTORY_BYTES + 1)
+            after = os.fstat(handle.fileno())
+    except (OSError, RuntimeError, ValueError):
+        return None
+    if (
+        len(raw) > _MAX_TRAJECTORY_BYTES
+        or (opened.st_dev, opened.st_ino, opened.st_size, opened.st_mtime_ns)
+        != (after.st_dev, after.st_ino, after.st_size, after.st_mtime_ns)
+        or hashlib.sha256(raw).hexdigest() != expected_sha
+    ):
+        return None
+    rows = []
+    for line in raw.splitlines():
+        if (
+            not line.strip()
+            or len(line) > _MAX_TRAJECTORY_LINE_BYTES
+            or len(rows) >= _MAX_TRAJECTORY_ROWS
+        ):
+            return None
+        try:
+            row = json.loads(line)
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            return None
+        if not isinstance(row, dict):
+            return None
+        rows.append(row)
+    return rows or None
+
+
+def _candidate_go_paths(metric):
+    audit = metric.get("patch_path_audit")
+    paths = audit.get("actual_paths") if isinstance(audit, dict) else None
+    extraction = metric.get("trusted_patch_extraction")
+    changed_paths = (
+        extraction.get("changed_paths") if isinstance(extraction, dict) else None
+    )
+    if not isinstance(paths, list) or not paths or len(paths) > 1024:
+        return None
+    if (
+        not isinstance(changed_paths, list)
+        or any(not isinstance(value, str) for value in paths)
+        or any(not isinstance(value, str) for value in changed_paths)
+        or len(paths) != len(set(paths))
+        or set(paths) != set(changed_paths)
+    ):
+        return None
+    result = []
+    for value in paths:
+        if (
+            not isinstance(value, str)
+            or not value
+            or value.startswith("/")
+            or ".." in Path(value).parts
+        ):
+            return None
+        if value.endswith(".go"):
+            result.append(value)
+    return tuple(result) or None
+
+
+def _tool_exec(row):
+    if row.get("type") != "tool_exec":
+        return None
+    payload = row.get("payload")
+    if not isinstance(payload, dict) or payload.get("tool") != "bash":
+        return None
+    args = payload.get("args")
+    command = args.get("command") if isinstance(args, dict) else None
+    result = payload.get("result")
+    if not isinstance(command, str) or not isinstance(result, str):
+        return None
+    return command, result
+
+
+def _candidate_go_compile_failure(result, candidate_paths):
+    for line in result.splitlines():
+        match = _GO_DIAGNOSTIC_RE.fullmatch(line.strip())
+        if match is None or match.group("path") not in candidate_paths:
+            continue
+        detail = match.group("detail").strip().lower()
+        if detail and not detail.startswith(("warning:", "note:")):
+            return True
+    return False
+
+
+def _tool_exit_code(result):
+    match = _TOOL_EXIT_RE.match(result)
+    return int(match.group("code")) if match is not None else None
+
+
+def _corrected_go_probe(command, result):
+    match = _CORRECTED_GO_PROBE_RE.fullmatch(command.strip())
+    exit_code = _tool_exit_code(result)
+    if match is None or exit_code is None:
+        return False
+    tail = match.group("tail").strip()
+    if tail == "./...":
+        return exit_code != 0
+    return bool(re.fullmatch(r"\./\.\.\.\s+2>&1\s*\|\s*head\s+-\d+", tail))
+
+
+def _uncorrected_go_probe(command, result):
+    match = _UNCORRECTED_GO_PROBE_RE.fullmatch(command.strip())
+    exit_code = _tool_exit_code(result)
+    if match is None or exit_code is None or "go: command not found" not in result.lower():
+        return False
+    tail = match.group("tail").strip()
+    if tail == "./...":
+        return exit_code != 0
+    return bool(re.fullmatch(r"\./\.\.\.\s+2>&1\s*\|\s*head\s+-\d+", tail))
+
+
+def _blocked_candidate_documents_match(prediction, metric):
+    embedded = embedded_workflow_metric(prediction)
+    fields = (
+        "trajectory_path",
+        "trajectory_sha256",
+        "patch_path_audit",
+        "trusted_patch_extraction",
+    )
+    return bool(
+        isinstance(embedded, dict)
+        and all(field in embedded and field in metric for field in fields)
+        and all(embedded[field] == metric[field] for field in fields)
+    )
+
+
+def _trajectory_final_verdict_matches(row, blocker):
+    if row.get("type") != "llm_call":
+        return False
+    payload = row.get("payload")
+    tool_calls = payload.get("tool_calls") if isinstance(payload, dict) else None
+    if not isinstance(tool_calls, list):
+        return False
+    for call in tool_calls:
+        if not isinstance(call, dict) or call.get("name") != "structured_output":
+            continue
+        arguments = call.get("arguments")
+        if not isinstance(arguments, str) or len(arguments.encode("utf-8")) > 64 * 1024:
+            continue
+        try:
+            verdict = json.loads(arguments)
+        except json.JSONDecodeError:
+            continue
+        if (
+            isinstance(verdict, dict)
+            and verdict.get("verdict") == "BLOCKED"
+            and verdict.get("findings") == blocker
+        ):
+            return True
+    return False
+
+
+def _blocked_candidate_failure_proven(
+    prediction,
+    metric,
+    matching_official_eval_attempts,
+):
+    if matching_official_eval_attempts != 0:
+        return False
+    result = metric.get("workflow_result")
+    blocker = result.get("blocker") if isinstance(result, dict) else None
+    attempts = result.get("attempts") if isinstance(result, dict) else None
+    if (
+        not isinstance(blocker, str)
+        or not isinstance(attempts, list)
+        or not attempts
+        or not isinstance(attempts[-1], dict)
+        or result.get("status") != "blocked"
+        or metric.get("execution_quiesced") is not True
+        or metric.get("container_execution_quiesced") is not True
+        or not _blocked_candidate_documents_match(prediction, metric)
+        or not current_generation_proof_valid(metric, prediction_patch(prediction))
+    ):
+        return False
+    verdict = attempts[-1].get("final_verdict")
+    if not (
+        isinstance(verdict, dict)
+        and verdict.get("verdict") == "BLOCKED"
+        and verdict.get("findings") == blocker
+    ):
+        return False
+    blocker_lower = blocker.lower()
+    if not all(
+        marker in blocker_lower
+        for marker in (
+            "go: command not found",
+            "/usr/local/go/bin/go",
+            "no usable output",
+        )
+    ):
+        return False
+    candidate_paths = _candidate_go_paths(metric)
+    rows = _bounded_verified_trajectory(metric)
+    if candidate_paths is None or rows is None:
+        return False
+    command_not_found_at = None
+    candidate_failure_at = None
+    for index, row in enumerate(rows):
+        execution = _tool_exec(row)
+        if execution is None:
+            continue
+        command, output = execution
+        if (
+            command_not_found_at is None
+            and _uncorrected_go_probe(command, output)
+        ):
+            command_not_found_at = index
+            continue
+        if (
+            command_not_found_at is not None
+            and index > command_not_found_at
+            and _corrected_go_probe(command, output)
+            and _candidate_go_compile_failure(output, candidate_paths)
+        ):
+            candidate_failure_at = index
+    if candidate_failure_at is None:
+        return False
+    return any(
+        index > candidate_failure_at and _trajectory_final_verdict_matches(row, blocker)
+        for index, row in enumerate(rows)
+    )
+
+
 def _matching_official_eval_attempt_count(run_dir, task):
     return sum(
         1
@@ -231,10 +506,16 @@ def eval_only_generation_identity_status(
         agent_failures = metric.get("agent_failures")
         if not _agent_failure_evidence_valid(agent_failures):
             return "invalid"
-        if not _blocked_technical_interruption_proven(
+        technical = _blocked_technical_interruption_proven(
             metric,
             matching_official_eval_attempts,
-        ):
+        )
+        candidate_failure = _blocked_candidate_failure_proven(
+            prediction,
+            metric,
+            matching_official_eval_attempts,
+        )
+        if not technical and not candidate_failure:
             return "invalid"
         identity_metric = dict(metric)
         identity_metric.pop("provider_failure", None)
@@ -243,7 +524,13 @@ def eval_only_generation_identity_status(
         # independently, while the original failure evidence remains untouched.
         identity_metric["agent_failures"] = []
         status = historical_generation_identity_status(prediction, identity_metric, task)
-        return "blocked_technical_verified" if status == "verified" else "invalid"
+        if status != "verified":
+            return "invalid"
+        return (
+            "blocked_technical_verified"
+            if technical
+            else "blocked_candidate_failure_verified"
+        )
     return historical_generation_identity_status(prediction, identity_metric, task)
 
 

--- a/src/opencollab_eval/engine/swe_v1_remote_evaluation.py
+++ b/src/opencollab_eval/engine/swe_v1_remote_evaluation.py
@@ -678,8 +678,9 @@ def main():
                 run_dir, task, eval_only=True
             )
             if done:
+                matching_attempts = _matching_official_eval_attempt_count(run_dir, task)
                 identity_status = eval_only_generation_identity_status(
-                    prediction, metric, task
+                    prediction, metric, task, matching_official_eval_attempts=matching_attempts
                 )
                 gen = reconcile_eval_only_candidate_identity(
                     generation_done_result(

--- a/tests/test_swe_v1_eval_only_candidate.py
+++ b/tests/test_swe_v1_eval_only_candidate.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import hashlib
+import json
+
 from swe_v1_prolite_runner_test_support import (
     _remote_namespace,
     _seed_remote_completed_generation,
@@ -88,6 +91,316 @@ def _eval_only_status(namespace, prediction, metric, task, attempts=0):
         task,
         matching_official_eval_attempts=attempts,
     )
+
+
+def _candidate_failure_blocker():
+    return (
+        "Executable verification could not be completed because go: command not found; "
+        "only /usr/local/go/bin/go was located after an explicit PATH export, and the "
+        "prior build command returned no usable output."
+    )
+
+
+def _candidate_failure_rows(blocker):
+    return [
+        {
+            "type": "tool_exec",
+            "payload": {
+                "tool": "bash",
+                "args": {"command": "cd /testbed && go build ./..."},
+                "result": "Exit code: 127\nstdout:\ngo: command not found\n",
+            },
+        },
+        {
+            "type": "tool_exec",
+            "payload": {
+                "tool": "bash",
+                "args": {
+                    "command": (
+                        "export PATH=$PATH:/usr/local/go/bin && cd /testbed "
+                        "&& go version && go build ./... 2>&1 | head -50"
+                    )
+                },
+                "result": (
+                    "Exit code: 0\nstdout:\ngo version go1.24.3 linux/amd64\n"
+                    "src/a.go:167:20: cannot use api.GetShares as handler\n"
+                ),
+            },
+        },
+        {
+            "type": "llm_call",
+            "payload": {
+                "tool_calls": [
+                    {
+                        "name": "structured_output",
+                        "arguments": json.dumps(
+                            {"verdict": "BLOCKED", "findings": blocker}
+                        ),
+                    }
+                ]
+            },
+        },
+    ]
+
+
+def _attach_candidate_failure_trajectory(
+    namespace,
+    prediction,
+    metric,
+    task,
+    *,
+    rows=None,
+    blocker=None,
+):
+    patch = "diff --git a/src/a.go b/src/a.go\n+current\n"
+    patch_sha = hashlib.sha256(patch.encode()).hexdigest()
+    prediction["model_patch"] = patch
+    prediction["patch_sha256"] = patch_sha
+    metric["patch_sha256"] = patch_sha
+    extraction = metric["trusted_patch_extraction"]
+    extraction["patch_sha256"] = patch_sha
+    extraction["patch_bytes"] = len(patch.encode())
+    extraction["changed_paths"] = ["src/a.go"]
+    extraction["path_modes"] = [
+        {"path": "src/a.go", "old_mode": "100644", "new_mode": "100644"}
+    ]
+    blocker = blocker or _candidate_failure_blocker()
+    rows = rows if rows is not None else _candidate_failure_rows(blocker)
+    trajectory = (
+        namespace["base_run_dir"]
+        / task
+        / "workflow_logs"
+        / "trajectories"
+        / "solver-test"
+        / "runtime-test"
+        / "orchestration.jsonl"
+    )
+    trajectory.parent.mkdir(parents=True, exist_ok=True)
+    raw = b"".join(
+        json.dumps(row, separators=(",", ":")).encode("utf-8") + b"\n"
+        for row in rows
+    )
+    trajectory.write_bytes(raw)
+    metric.update(
+        trajectory_path=str(trajectory),
+        trajectory_sha256=hashlib.sha256(raw).hexdigest(),
+        patch_path_audit={"actual_paths": ["src/a.go"]},
+        workflow_result={
+            "status": "blocked",
+            "blocker": blocker,
+            "attempts": [
+                {
+                    "final_verdict": {
+                        "verdict": "BLOCKED",
+                        "findings": blocker,
+                    }
+                }
+            ],
+        },
+    )
+    prediction["workflow_metric"] = dict(metric)
+    return trajectory
+
+
+def test_eval_only_accepts_blocked_candidate_with_bound_compile_failure(tmp_path):
+    namespace = _namespace(tmp_path)
+    task = "task-1"
+    prediction, metric, _pairing = _blocked_candidate(namespace, task)
+    _attach_candidate_failure_trajectory(namespace, prediction, metric, task)
+
+    assert (
+        _eval_only_status(namespace, prediction, metric, task)
+        == "blocked_candidate_failure_verified"
+    )
+
+
+@pytest.mark.parametrize(
+    "rows",
+    [
+        _candidate_failure_rows(_candidate_failure_blocker())[1:],
+        [
+            _candidate_failure_rows(_candidate_failure_blocker())[0],
+            {
+                "type": "tool_exec",
+                "payload": {
+                    "tool": "bash",
+                    "args": {
+                        "command": (
+                            "export PATH=$PATH:/usr/local/go/bin && go build ./..."
+                        )
+                    },
+                    "result": "",
+                },
+            },
+            _candidate_failure_rows(_candidate_failure_blocker())[2],
+        ],
+        [
+            _candidate_failure_rows(_candidate_failure_blocker())[0],
+            {
+                "type": "tool_exec",
+                "payload": {
+                    "tool": "bash",
+                    "args": {
+                        "command": (
+                            "export PATH=$PATH:/usr/local/go/bin && go build ./..."
+                        )
+                    },
+                    "result": "Exit code: 0\nstdout:\n",
+                },
+            },
+            _candidate_failure_rows(_candidate_failure_blocker())[2],
+        ],
+        [
+            _candidate_failure_rows(_candidate_failure_blocker())[0],
+            {
+                "type": "tool_exec",
+                "payload": {
+                    "tool": "bash",
+                    "args": {
+                        "command": (
+                            "export PATH=$PATH:/usr/local/go/bin && go build ./..."
+                        )
+                    },
+                    "result": (
+                        "other/package/file.go:10:2: undefined: candidateSymbol\n"
+                    ),
+                },
+            },
+            _candidate_failure_rows(_candidate_failure_blocker())[2],
+        ],
+        [
+            _candidate_failure_rows(_candidate_failure_blocker())[0],
+            {
+                "type": "tool_exec",
+                "payload": {
+                    "tool": "bash",
+                    "args": {
+                        "command": (
+                            "export PATH=$PATH:/usr/local/go/bin && go build ./..."
+                        )
+                    },
+                    "result": (
+                        "src/a.go:167:20: warning: deprecated\n"
+                    ),
+                },
+            },
+            _candidate_failure_rows(_candidate_failure_blocker())[2],
+        ],
+        _candidate_failure_rows(_candidate_failure_blocker())[:2],
+    ],
+)
+def test_eval_only_rejects_blocked_candidate_without_complete_compile_trace(
+    tmp_path,
+    rows,
+):
+    namespace = _namespace(tmp_path)
+    task = "task-1"
+    prediction, metric, _pairing = _blocked_candidate(namespace, task)
+    _attach_candidate_failure_trajectory(
+        namespace,
+        prediction,
+        metric,
+        task,
+        rows=rows,
+    )
+
+    assert _eval_only_status(namespace, prediction, metric, task) == "invalid"
+
+
+def test_eval_only_rejects_compile_trace_with_semantic_blocker(tmp_path):
+    namespace = _namespace(tmp_path)
+    task = "task-1"
+    prediction, metric, _pairing = _blocked_candidate(namespace, task)
+    blocker = "Candidate semantics do not satisfy the requested behavior."
+    _attach_candidate_failure_trajectory(
+        namespace, prediction, metric, task, blocker=blocker, rows=_candidate_failure_rows(blocker)
+    )
+
+    assert _eval_only_status(namespace, prediction, metric, task) == "invalid"
+
+
+def test_eval_only_rejects_compile_trace_with_mismatched_digest(tmp_path):
+    namespace = _namespace(tmp_path)
+    task = "task-1"
+    prediction, metric, _pairing = _blocked_candidate(namespace, task)
+    _attach_candidate_failure_trajectory(namespace, prediction, metric, task)
+    metric["trajectory_sha256"] = "0" * 64
+    prediction["workflow_metric"] = dict(metric)
+
+    assert _eval_only_status(namespace, prediction, metric, task) == "invalid"
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        lambda prediction, metric: prediction["workflow_metric"].__setitem__("trajectory_sha256", "0" * 64),
+        lambda prediction, metric: prediction["workflow_metric"].__setitem__(
+            "patch_path_audit", {"actual_paths": ["other/file.go"]}),
+        lambda prediction, metric: prediction["workflow_metric"].__setitem__(
+            "trusted_patch_extraction", {"changed_paths": ["other/file.go"]}),
+        lambda prediction, metric: metric.__setitem__("execution_quiesced", False),
+        lambda prediction, metric: metric.__setitem__("container_execution_quiesced", False),
+        lambda prediction, metric: metric["workflow_result"].__setitem__("status", "completed"),
+        lambda prediction, metric: (
+            prediction["workflow_metric"].__setitem__("patch_path_audit", {"actual_paths": [{}]}),
+            metric.__setitem__("patch_path_audit", {"actual_paths": [{}]})),
+    ],
+)
+def test_eval_only_rejects_candidate_failure_with_divergent_or_live_identity(
+    tmp_path,
+    mutation,
+):
+    namespace = _namespace(tmp_path)
+    task = "task-1"
+    prediction, metric, _pairing = _blocked_candidate(namespace, task)
+    _attach_candidate_failure_trajectory(namespace, prediction, metric, task)
+    mutation(prediction, metric)
+
+    assert _eval_only_status(namespace, prediction, metric, task) == "invalid"
+
+
+@pytest.mark.parametrize(
+    ("command", "result"),
+    [
+        (
+            "echo /usr/local/go/bin && cd /testbed && go build ./...",
+            "Exit code: 1\nstdout:\nsrc/a.go:167:20: cannot use candidate\n",
+        ),
+        (
+            "export PATH=$PATH:/usr/local/go/bin && cd /testbed && go build ./... || true",
+            "Exit code: 0\nstdout:\nsrc/a.go:167:20: cannot use candidate\n",
+        ),
+        (
+            "export PATH=$PATH:/usr/local/go/bin && cd /testbed && go build ./...",
+            "Exit code: 0\nstdout:\nsrc/a.go:167:20: cannot use candidate\n",
+        ),
+        (
+            "export PATH=$PATH:/usr/local/go/bin && cd /testbed && "
+            "go build ./... || printf 'src/a.go:1:1: forged\\n'; false",
+            "Exit code: 1\nstdout:\nsrc/a.go:1:1: forged\n",
+        ),
+    ],
+)
+def test_eval_only_rejects_untrusted_corrected_probe(tmp_path, command, result):
+    namespace = _namespace(tmp_path)
+    task = "task-1"
+    prediction, metric, _pairing = _blocked_candidate(namespace, task)
+    blocker = _candidate_failure_blocker()
+    rows = _candidate_failure_rows(blocker)
+    rows[1]["payload"]["args"]["command"] = command
+    rows[1]["payload"]["result"] = result
+    _attach_candidate_failure_trajectory(namespace, prediction, metric, task, rows=rows)
+
+    assert _eval_only_status(namespace, prediction, metric, task) == "invalid"
+
+
+def test_eval_only_rejects_compile_trace_after_official_attempt(tmp_path):
+    namespace = _namespace(tmp_path)
+    task = "task-1"
+    prediction, metric, _pairing = _blocked_candidate(namespace, task)
+    _attach_candidate_failure_trajectory(namespace, prediction, metric, task)
+
+    assert _eval_only_status(namespace, prediction, metric, task, attempts=1) == "invalid"
 
 
 def test_eval_only_accepts_proven_blocked_candidate_with_no_provider_failure(tmp_path):

--- a/tests/test_swe_v1_eval_only_candidate.py
+++ b/tests/test_swe_v1_eval_only_candidate.py
@@ -58,6 +58,19 @@ def _blocked_candidate(namespace, task, **overrides):
         agent_failures=[],
         provider_failure=False,
         submission_eligible=True,
+        container_execution_quiesced=True,
+        workflow_result={
+            "status": "blocked",
+            "blocker": "Execution environment has been aborted during verification.",
+            "attempts": [
+                {
+                    "final_verdict": {
+                        "verdict": "BLOCKED",
+                        "findings": "Execution environment has been aborted during verification.",
+                    }
+                }
+            ],
+        },
     )
     metrics[0].update(overrides)
     _write_jsonl(metrics_path, metrics)
@@ -66,6 +79,15 @@ def _blocked_candidate(namespace, task, **overrides):
     predictions[0]["workflow_metric"] = dict(metrics[0])
     _write_jsonl(predictions_path, predictions)
     return namespace["latest_pair"](namespace["base_run_dir"] / task, task)
+
+
+def _eval_only_status(namespace, prediction, metric, task, attempts=0):
+    return namespace["eval_only_generation_identity_status"](
+        prediction,
+        metric,
+        task,
+        matching_official_eval_attempts=attempts,
+    )
 
 
 def test_eval_only_accepts_proven_blocked_candidate_with_no_provider_failure(tmp_path):
@@ -79,9 +101,7 @@ def test_eval_only_accepts_proven_blocked_candidate_with_no_provider_failure(tmp
     assert namespace["historical_generation_identity_status"](
         prediction, metric, task
     ) == "invalid"
-    assert namespace["eval_only_generation_identity_status"](
-        prediction, metric, task
-    ) == "verified"
+    assert _eval_only_status(namespace, prediction, metric, task) == "blocked_technical_verified"
     assert namespace["generation_done"](
         namespace["base_run_dir"] / task, task, require_identity=False
     )[0] is False
@@ -106,10 +126,149 @@ def test_eval_only_accepts_proven_blocked_candidate_with_agent_failure_evidence(
         ],
     )
 
-    assert namespace["eval_only_generation_identity_status"](
-        prediction, metric, task
-    ) == "verified"
+    assert _eval_only_status(namespace, prediction, metric, task) == "blocked_technical_verified"
     assert metric["agent_failures"][0]["exception_type"] == "ResponsesProtocolError"
+
+
+def test_eval_only_rejects_blocked_candidate_after_official_attempt(tmp_path):
+    namespace = _namespace(tmp_path)
+    task = "task-1"
+    prediction, metric, _pairing = _blocked_candidate(namespace, task)
+    _write_jsonl(
+        namespace["base_run_dir"] / task / "eval_attempts.jsonl",
+        [
+            {
+                "phase": "eval_attempt_started",
+                "task": task,
+                "record_id": "different-record",
+            }
+        ],
+    )
+
+    assert _eval_only_status(namespace, prediction, metric, task, attempts=1) == "invalid"
+    assert (
+        namespace["generation_done_for_mode"](
+            namespace["base_run_dir"] / task,
+            task,
+            eval_only=True,
+        )[0]
+        is False
+    )
+
+
+@pytest.mark.parametrize(
+    "workflow_result",
+    [
+        None,
+        {},
+        {"status": "failed"},
+        {
+            "status": "blocked",
+            "blocker": "Verifier returned no evidence.",
+            "attempts": [],
+        },
+        {
+            "status": "blocked",
+            "blocker": "Execution environment has been aborted during verification.",
+            "attempts": [],
+        },
+        {
+            "status": "blocked",
+            "blocker": "Execution environment has been aborted during verification.",
+            "attempts": [
+                {
+                    "final_verdict": {
+                        "verdict": "FAIL",
+                        "findings": "Execution environment has been aborted during verification.",
+                    }
+                }
+            ],
+        },
+        {
+            "status": "blocked",
+            "blocker": "Execution environment has been aborted during verification.",
+            "attempts": [
+                {
+                    "final_verdict": {
+                        "verdict": "BLOCKED",
+                        "findings": "different evidence",
+                    }
+                }
+            ],
+        },
+    ],
+)
+def test_eval_only_rejects_blocked_candidate_without_causal_technical_evidence(
+    tmp_path,
+    workflow_result,
+):
+    namespace = _namespace(tmp_path)
+    task = "task-1"
+    prediction, metric, _pairing = _blocked_candidate(
+        namespace,
+        task,
+        workflow_result=workflow_result,
+    )
+
+    assert _eval_only_status(namespace, prediction, metric, task) == "invalid"
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("workflow_status", "failed"),
+        ("runner_returncode", 0),
+        ("runtime_status", "failed"),
+        ("error", "different error"),
+        ("submission_eligible", False),
+        ("execution_quiesced", False),
+        ("container_execution_quiesced", False),
+        (
+            "workflow_result",
+            {
+                "status": "blocked",
+                "blocker": "Verifier rejected the candidate semantics.",
+                "attempts": [
+                    {
+                        "final_verdict": {
+                            "verdict": "BLOCKED",
+                            "findings": "Verifier rejected the candidate semantics.",
+                        }
+                    }
+                ],
+            },
+        ),
+    ],
+)
+def test_eval_only_rejects_mismatched_embedded_causal_evidence(tmp_path, field, value):
+    namespace = _namespace(tmp_path)
+    task = "task-1"
+    prediction, metric, _pairing = _blocked_candidate(namespace, task)
+    prediction["workflow_metric"][field] = value
+
+    assert _eval_only_status(namespace, prediction, metric, task) == "invalid"
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "workflow_status",
+        "runner_returncode",
+        "runtime_status",
+        "error",
+        "submission_eligible",
+        "execution_quiesced",
+        "container_execution_quiesced",
+        "workflow_result",
+    ],
+)
+def test_eval_only_rejects_one_sided_causal_evidence(tmp_path, field):
+    namespace = _namespace(tmp_path)
+    task = "task-1"
+    prediction, metric, _pairing = _blocked_candidate(namespace, task)
+    prediction["workflow_metric"].pop(field)
+
+    assert _eval_only_status(namespace, prediction, metric, task) == "invalid"
 
 
 def test_eval_only_accepts_legacy_blocked_candidate_without_provider_failure_fields(tmp_path):
@@ -119,9 +278,7 @@ def test_eval_only_accepts_legacy_blocked_candidate_without_provider_failure_fie
     prediction["workflow_metric"].pop("provider_failure")
     metric.pop("provider_failure")
 
-    assert namespace["eval_only_generation_identity_status"](
-        prediction, metric, task
-    ) == "verified"
+    assert _eval_only_status(namespace, prediction, metric, task) == "blocked_technical_verified"
 
 
 @pytest.mark.parametrize("document", ["metric", "embedded"])
@@ -132,9 +289,7 @@ def test_eval_only_rejects_one_sided_provider_failure_field(tmp_path, document):
     target = metric if document == "metric" else prediction["workflow_metric"]
     target.pop("provider_failure")
 
-    assert namespace["eval_only_generation_identity_status"](
-        prediction, metric, task
-    ) == "invalid"
+    assert _eval_only_status(namespace, prediction, metric, task) == "invalid"
 
 
 @pytest.mark.parametrize(
@@ -183,9 +338,7 @@ def test_eval_only_rejects_malformed_agent_failure_evidence(tmp_path, agent_fail
         agent_failures=agent_failures,
     )
 
-    assert namespace["eval_only_generation_identity_status"](
-        prediction, metric, task
-    ) == "invalid"
+    assert _eval_only_status(namespace, prediction, metric, task) == "invalid"
 
 
 @pytest.mark.parametrize("field", ["provider_failure", "agent_failures"])
@@ -205,9 +358,7 @@ def test_eval_only_rejects_mismatched_embedded_failure_evidence(tmp_path, field)
             }
         ]
 
-    assert namespace["eval_only_generation_identity_status"](
-        prediction, metric, task
-    ) == "invalid"
+    assert _eval_only_status(namespace, prediction, metric, task) == "invalid"
 
 
 @pytest.mark.parametrize("transport", ["direct", "reverse_proxy"])
@@ -221,9 +372,7 @@ def test_eval_only_accepts_matching_explicit_transport(tmp_path, transport):
     assert namespace["_normalized_historical_llm_transport"](
         prediction["workflow_metric"], metric
     ) == transport
-    assert namespace["eval_only_generation_identity_status"](
-        prediction, metric, task
-    ) == "verified"
+    assert _eval_only_status(namespace, prediction, metric, task) == "blocked_technical_verified"
 
 
 @pytest.mark.parametrize("document", ["metric", "embedded"])
@@ -234,9 +383,7 @@ def test_eval_only_rejects_one_sided_transport(tmp_path, document):
     target = metric if document == "metric" else prediction["workflow_metric"]
     target["llm_transport"] = "direct"
 
-    assert namespace["eval_only_generation_identity_status"](
-        prediction, metric, task
-    ) == "invalid"
+    assert _eval_only_status(namespace, prediction, metric, task) == "invalid"
 
 
 @pytest.mark.parametrize("transport", ["", "proxy", "DIRECT", None, 1])
@@ -247,9 +394,7 @@ def test_eval_only_rejects_invalid_matching_transport(tmp_path, transport):
     prediction["workflow_metric"]["llm_transport"] = transport
     metric["llm_transport"] = transport
 
-    assert namespace["eval_only_generation_identity_status"](
-        prediction, metric, task
-    ) == "invalid"
+    assert _eval_only_status(namespace, prediction, metric, task) == "invalid"
 
 
 def test_eval_only_rejects_mismatched_transport(tmp_path):
@@ -259,9 +404,7 @@ def test_eval_only_rejects_mismatched_transport(tmp_path):
     prediction["workflow_metric"]["llm_transport"] = "reverse_proxy"
     metric["llm_transport"] = "direct"
 
-    assert namespace["eval_only_generation_identity_status"](
-        prediction, metric, task
-    ) == "invalid"
+    assert _eval_only_status(namespace, prediction, metric, task) == "invalid"
 
 
 @pytest.mark.parametrize(
@@ -270,6 +413,7 @@ def test_eval_only_rejects_mismatched_transport(tmp_path):
         ("provider_failure", True),
         ("submission_eligible", False),
         ("execution_quiesced", False),
+        ("container_execution_quiesced", False),
         ("patch_extraction_succeeded", False),
         ("trusted_patch_extraction", {}),
     ],
@@ -285,9 +429,7 @@ def test_eval_only_rejects_blocked_candidate_without_complete_proof(
         namespace, task, **{field: value}
     )
 
-    assert namespace["eval_only_generation_identity_status"](
-        prediction, metric, task
-    ) == "invalid"
+    assert _eval_only_status(namespace, prediction, metric, task) == "invalid"
 
 
 def _tampered(value):
@@ -323,9 +465,7 @@ def test_eval_only_rejects_incomplete_or_tampered_identity_document(
     else:
         target[key] = _tampered(target[key])
 
-    assert namespace["eval_only_generation_identity_status"](
-        prediction, metric, task
-    ) == "invalid"
+    assert _eval_only_status(namespace, prediction, metric, task) == "invalid"
 
 
 @pytest.mark.parametrize("field", ["model", "workflow"])
@@ -344,6 +484,4 @@ def test_eval_only_rejects_prediction_identity_document_tampering(
     else:
         prediction[key] = _tampered(prediction[key])
 
-    assert namespace["eval_only_generation_identity_status"](
-        prediction, metric, task
-    ) == "invalid"
+    assert _eval_only_status(namespace, prediction, metric, task) == "invalid"

--- a/tests/test_swe_v1_prolite_runner_parent_eval.py
+++ b/tests/test_swe_v1_prolite_runner_parent_eval.py
@@ -575,3 +575,27 @@ def test_eval_only_cli_rejects_a_multi_task_slice(tmp_path):
 
     assert proc.returncode == 2
     assert "--eval-only requires --limit 1" in proc.stderr
+
+
+def test_eval_only_cli_requires_zero_task_starts(tmp_path):
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "opencollab_eval.commands.swe_v1_prolite_runner",
+            "--eval-only",
+            "--parent-output-dir",
+            str(tmp_path),
+            "--limit",
+            "1",
+            "--max-task-starts",
+            "1",
+            "--dry-run",
+        ],
+        cwd=Path(__file__).resolve().parents[1],
+        text=True,
+        capture_output=True,
+    )
+
+    assert proc.returncode == 2
+    assert "--eval-only requires --max-task-starts 0" in proc.stderr

--- a/tests/test_trusted_host_checkpoint_config.py
+++ b/tests/test_trusted_host_checkpoint_config.py
@@ -45,6 +45,8 @@ def test_standalone_allows_legacy_checkpoint_value_for_eval_only(
                 str(tmp_path),
                 "--limit",
                 "1",
+                "--max-task-starts",
+                "0",
                 "--checkpoint-interval",
                 "30",
                 "--host",


### PR DESCRIPTION
此变更为 blocked 候选建立两类严格的 eval-only 身份门禁。技术中断身份继续要求生成证明、提交完整性、双文档因果字段、执行静止状态以及零次 official eval attempt 全部成立。

新增的候选编译失败身份要求双文档绑定轨迹路径、轨迹 SHA、补丁路径审计和可信提取证明。补丁路径必须与可信 changed paths 一致。绑定轨迹必须先出现未修正 PATH 的 Go 探针失败，再出现显式导出 /usr/local/go/bin 后执行的 Go build 或 test，并在候选改动文件中产生编译器错误。最终 BLOCKED 结论必须晚于该错误且与工作流文档完全一致。普通探针必须返回非零。仅对精确的 head 截断结构接受管道掩盖的零退出码。伪诊断、吞错命令、无关路径、畸形路径、证据分叉和仍在执行的候选全部拒绝。

eval-only 命令现强制 max_task_starts 为零，因此该身份只能进入一次 official eval，无法触发模型生成或离线计分。

Ruff、246 项相关回归、文件卫生和完整 pytest 均通过。完整结果为 2731 passed、16 skipped。独立 Reviewer 最终明确 APPROVE。题 26 的真实 SHA 绑定轨迹已用固定 runtime 只读重放，身份为 blocked_candidate_failure_verified。固定 runtime tree SHA 为 43b7685c012510912b00e6e257afdc7e8c4febcf1a4901d3a3d39f8b49882773。