### PR TITLE
chore(release): 准备 OpenCollab-Eval 0.5.1 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to OpenCollab-Eval are recorded in this file.
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-09-04
+
+### Fixed
+
+- Accepted legacy per-instance sidecars that identify a task with `task` or
+  `task_id`, while normalizing valid patch digests without weakening conflict
+  or format checks.
+- Preserved eligible, quiescent candidates when OpenCollab ends a run through
+  the protected budget reserve or provider output truncation; incomplete
+  evidence remains a technical failure.
+
 ## [0.5.0] - 2026-08-13
 
 ### Added
@@ -26,5 +37,6 @@ All notable changes to OpenCollab-Eval are recorded in this file.
 - Prevented stale checkpoints, malformed streaming responses, duplicate model starts, cleanup races, and parser-specific evidence gaps from producing untrusted terminal results.
 - Raised the deterministic SWE test budget so OpenCollab 0.5.0 can preserve the configured output allowance after conservative input reservation.
 
-[Unreleased]: https://github.com/RISE-X-Lab/OpenCollab-Eval/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/RISE-X-Lab/OpenCollab-Eval/compare/v0.5.1...HEAD
+[0.5.1]: https://github.com/RISE-X-Lab/OpenCollab-Eval/releases/tag/v0.5.1
 [0.5.0]: https://github.com/RISE-X-Lab/OpenCollab-Eval/releases/tag/v0.5.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ python -m build --wheel --outdir "$wheel_root/opencollab" ../OpenCollab
 python -m build --wheel --outdir "$wheel_root/eval" .
 scripts/verify_wheel_contract.sh \
   "$wheel_root"/opencollab/opencollab-0.5*.whl \
-  "$wheel_root"/eval/opencollab_eval-0.5.0*.whl
+  "$wheel_root"/eval/opencollab_eval-0.5.1*.whl
 ```
 
 The deterministic SWE E2E requires Docker, `sshd`, `ssh`, `ssh-keygen`, and

--- a/CONTRIBUTING.zh-CN.md
+++ b/CONTRIBUTING.zh-CN.md
@@ -26,7 +26,7 @@ python -m build --wheel --outdir "$wheel_root/opencollab" ../OpenCollab
 python -m build --wheel --outdir "$wheel_root/eval" .
 scripts/verify_wheel_contract.sh \
   "$wheel_root"/opencollab/opencollab-0.5*.whl \
-  "$wheel_root"/eval/opencollab_eval-0.5.0*.whl
+  "$wheel_root"/eval/opencollab_eval-0.5.1*.whl
 ```
 
 确定性 SWE E2E 要求安装 Docker、`sshd`、`ssh`、`ssh-keygen` 和 `rsync`。其中的模型请求发往本地伪服务，因此无需提供方凭据。

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -26,7 +26,9 @@ tree identity, and then imports from that synchronized package root.
 
 ## OpenCollab version boundary
 
-OpenCollab-Eval 0.5.0 requires OpenCollab 0.5.0. This paired release provides
+OpenCollab-Eval 0.5.1 requires OpenCollab 0.5.0. This patch release preserves
+the 0.5.0 pair while correcting legacy result and controlled-stop handling. The
+paired release provides
 the Responses transport, runtime identity checks, and public test contracts
 used by the current evaluator. The package root provides `OpenCollab`,
 `RunResult`, `RunError`, and `workflow`. Optional public contracts and

--- a/MIGRATION.zh-CN.md
+++ b/MIGRATION.zh-CN.md
@@ -20,7 +20,7 @@ OpenCollab-Eval 负责基准与评测代码，其中包括 Solver 工作流和�
 
 ## OpenCollab 版本边界
 
-OpenCollab-Eval 0.5.0 要求使用 OpenCollab 0.5.0。这组配套版本提供当前评测器使用的 Responses 传输、运行时身份检查与公开测试契约。软件包根目录提供 `OpenCollab`、`RunResult`、`RunError` 和 `workflow`。可选的公开契约与组合辅助工具位于 `opencollab.environments`、`opencollab.tools` 和 `opencollab.workflows`。
+OpenCollab-Eval 0.5.1 要求使用 OpenCollab 0.5.0。本补丁版本保持 0.5.0 配套关系，同时修正旧版结果与受控停止处理。这组配套版本提供当前评测器使用的 Responses 传输、运行时身份检查与公开测试契约。软件包根目录提供 `OpenCollab`、`RunResult`、`RunError` 和 `workflow`。可选的公开契约与组合辅助工具位于 `opencollab.environments`、`opencollab.tools` 和 `opencollab.workflows`。
 
 生产代码和测试禁止导入已弃用的 `opencollab.sdk` 命名空间，以及内部的 `opencollab.adapters`、`opencollab.application`、`opencollab.bootstrap`、`opencollab.domain` 和 `opencollab.harness` 命名空间。边界测试会对源码和已安装的 wheel 强制执行这项规则。
 

--- a/README.md
+++ b/README.md
@@ -63,13 +63,13 @@ Install the two wheel files.
 
 ```bash
 python -m pip install /path/to/opencollab-0.5.0-py3-none-any.whl
-python -m pip install /path/to/opencollab_eval-0.5.0-py3-none-any.whl
+python -m pip install /path/to/opencollab_eval-0.5.1-py3-none-any.whl
 ```
 
 Install the SWE-bench integration when official evaluation is needed.
 
 ```bash
-python -m pip install '/path/to/opencollab_eval-0.5.0-py3-none-any.whl[swebench]'
+python -m pip install '/path/to/opencollab_eval-0.5.1-py3-none-any.whl[swebench]'
 ```
 
 For a source checkout, install the matching OpenCollab repository first.
@@ -282,7 +282,7 @@ ruff check .
 pytest -q
 scripts/verify_wheel_contract.sh \
   /path/to/opencollab-0.5.0-py3-none-any.whl \
-  /path/to/opencollab_eval-0.5.0-py3-none-any.whl
+  /path/to/opencollab_eval-0.5.1-py3-none-any.whl
 scripts/run_deterministic_swe_e2e.sh --output /tmp/oce-e2e --runs 1
 ```
 
@@ -348,13 +348,13 @@ OpenCollab-Eval 支持 Python 3.10 及以上版本，并要求 OpenCollab 0.5.0 
 
 ```bash
 python -m pip install /path/to/opencollab-0.5.0-py3-none-any.whl
-python -m pip install /path/to/opencollab_eval-0.5.0-py3-none-any.whl
+python -m pip install /path/to/opencollab_eval-0.5.1-py3-none-any.whl
 ```
 
 需要官方评测时，安装 SWE-bench 集成。
 
 ```bash
-python -m pip install '/path/to/opencollab_eval-0.5.0-py3-none-any.whl[swebench]'
+python -m pip install '/path/to/opencollab_eval-0.5.1-py3-none-any.whl[swebench]'
 ```
 
 使用源码检出时，先安装与之匹配的 OpenCollab 仓库。
@@ -520,7 +520,7 @@ ruff check .
 pytest -q
 scripts/verify_wheel_contract.sh \
   /path/to/opencollab-0.5.0-py3-none-any.whl \
-  /path/to/opencollab_eval-0.5.0-py3-none-any.whl
+  /path/to/opencollab_eval-0.5.1-py3-none-any.whl
 scripts/run_deterministic_swe_e2e.sh --output /tmp/oce-e2e --runs 1
 ```
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -36,12 +36,13 @@ Build the OpenCollab wheel from its published tag, then build the evaluator sour
 
 ```bash
 set -euo pipefail
-release_version=0.5.0
+release_version=0.5.1
+opencollab_release_tag=v0.5.0
 opencollab_release_sha=963585611ad2a1d0c1fc7f4ba0043af5a3d860bb
 artifact_root="$(mktemp -d -t "opencollab-eval-${release_version}.XXXXXX")"
 mkdir -p "$artifact_root/opencollab" "$artifact_root/sdist" "$artifact_root/wheel" "$artifact_root/assets"
 
-test "$(git -C ../OpenCollab rev-parse "v${release_version}^{}")" = "$opencollab_release_sha"
+test "$(git -C ../OpenCollab rev-parse "${opencollab_release_tag}^{}")" = "$opencollab_release_sha"
 test "$(git -C ../OpenCollab rev-parse HEAD)" = "$opencollab_release_sha"
 test -z "$(git -C ../OpenCollab status --porcelain)"
 uv build --wheel --no-sources --out-dir "$artifact_root/opencollab" ../OpenCollab

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -22,7 +22,7 @@ wheels and verifies the installed boundary.
 python -m venv .venv
 . .venv/bin/activate
 python -m pip install /path/to/opencollab-0.5.0-py3-none-any.whl
-python -m pip install /path/to/opencollab_eval-0.5.0-py3-none-any.whl
+python -m pip install /path/to/opencollab_eval-0.5.1-py3-none-any.whl
 oc-eval --version
 oc-eval --help
 ```
@@ -30,13 +30,13 @@ oc-eval --help
 Install official SWE-bench support with the package extra.
 
 ```bash
-python -m pip install '/path/to/opencollab_eval-0.5.0-py3-none-any.whl[swebench]'
+python -m pip install '/path/to/opencollab_eval-0.5.1-py3-none-any.whl[swebench]'
 ```
 
 Install OpenHands support in a Python 3.12 environment.
 
 ```bash
-python -m pip install '/path/to/opencollab_eval-0.5.0-py3-none-any.whl[openhands]'
+python -m pip install '/path/to/opencollab_eval-0.5.1-py3-none-any.whl[openhands]'
 ```
 
 ## Install source checkouts

--- a/docs/zh-CN/getting-started.md
+++ b/docs/zh-CN/getting-started.md
@@ -16,7 +16,7 @@
 python -m venv .venv
 . .venv/bin/activate
 python -m pip install /path/to/opencollab-0.5.0-py3-none-any.whl
-python -m pip install /path/to/opencollab_eval-0.5.0-py3-none-any.whl
+python -m pip install /path/to/opencollab_eval-0.5.1-py3-none-any.whl
 oc-eval --version
 oc-eval --help
 ```
@@ -24,13 +24,13 @@ oc-eval --help
 通过软件包的可选依赖安装官方 SWE-bench 支持。
 
 ```bash
-python -m pip install '/path/to/opencollab_eval-0.5.0-py3-none-any.whl[swebench]'
+python -m pip install '/path/to/opencollab_eval-0.5.1-py3-none-any.whl[swebench]'
 ```
 
 在 Python 3.12 环境中安装 OpenHands 支持。
 
 ```bash
-python -m pip install '/path/to/opencollab_eval-0.5.0-py3-none-any.whl[openhands]'
+python -m pip install '/path/to/opencollab_eval-0.5.1-py3-none-any.whl[openhands]'
 ```
 
 ## 安装源码检出

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "opencollab-eval"
-version = "0.5.0"
+version = "0.5.1"
 description = "Independent evaluation layer for OpenCollab solvers."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/opencollab_eval/__init__.py
+++ b/src/opencollab_eval/__init__.py
@@ -1,3 +1,3 @@
 """Independent evaluation layer for OpenCollab-based solvers."""
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"

--- a/src/opencollab_eval/commands/swebench_eval_records.py
+++ b/src/opencollab_eval/commands/swebench_eval_records.py
@@ -17,6 +17,7 @@ import unicodedata
 from pathlib import Path, PureWindowsPath
 
 from opencollab_eval.engine import swe_eval_records as swe_records
+from opencollab_eval.engine.swe_eval_record_identity import direct_payload_task_id
 from opencollab_eval.engine.swe_eval_records import (
     MAX_JSON_DOCUMENT_BYTES,
     SUBMISSION_INTEGRITY_PROVEN,
@@ -648,11 +649,14 @@ def report_is_done(path: Path, instance_id: str, expected_identity: dict) -> boo
         return False
     if attempt.get("status") not in {"launching", "started", "completed"}:
         return False
-    if str(attempt.get("instance_id") or "") != instance_id:
+    if direct_payload_task_id(attempt) != instance_id:
         return False
     if str(attempt.get("record_id") or "") != str(expected_identity.get("record_id") or ""):
         return False
-    if str(attempt.get("patch_sha256") or "") != str(expected_identity.get("patch_sha256") or ""):
+    if not swe_records.patch_sha_matches(
+        attempt.get("patch_sha256"),
+        expected_identity.get("patch_sha256"),
+    ):
         return False
     if "prior_report_fingerprint" in attempt:
         # A report format without an embedded patch identity must not reuse the

--- a/src/opencollab_eval/engine/evaluator_sessions.py
+++ b/src/opencollab_eval/engine/evaluator_sessions.py
@@ -33,6 +33,7 @@ _CONTROLLED_STOP_REASON_PREFIXES = (
     "team budget exceeded:",
     "step limit reached:",
     "context overflow:",
+    "output truncated:",
 )
 
 

--- a/src/opencollab_eval/engine/evaluator_sessions.py
+++ b/src/opencollab_eval/engine/evaluator_sessions.py
@@ -31,6 +31,7 @@ _CONTROLLED_STOP_REASON_PREFIXES = (
     "budget exceeded after model call:",
     "budget exhausted before model call:",
     "team budget exceeded:",
+    "budget reserve exhausted:",
     "step limit reached:",
     "context overflow:",
     "output truncated:",

--- a/src/opencollab_eval/generation/gen_prediction_agent.py
+++ b/src/opencollab_eval/generation/gen_prediction_agent.py
@@ -32,6 +32,7 @@ _CONTROLLED_STOP_REASON_PREFIXES = (
     "team budget exceeded:",
     "step limit reached:",
     "context overflow:",
+    "output truncated:",
 )
 _CONTROLLED_STOP_REASON_NAMES = frozenset(
     {"budget_exceeded", "context_overflow", "step_limit_exceeded", "timeout"}

--- a/src/opencollab_eval/generation/gen_prediction_agent.py
+++ b/src/opencollab_eval/generation/gen_prediction_agent.py
@@ -30,6 +30,7 @@ _CONTROLLED_STOP_REASON_PREFIXES = (
     "budget exceeded after model call:",
     "budget exhausted before model call:",
     "team budget exceeded:",
+    "budget reserve exhausted:",
     "step limit reached:",
     "context overflow:",
     "output truncated:",

--- a/src/opencollab_eval/generation/gen_prediction_workflow.py
+++ b/src/opencollab_eval/generation/gen_prediction_workflow.py
@@ -101,6 +101,7 @@ _CONTROLLED_STOP_REASON_PREFIXES = (
     "team budget exceeded:",
     "step limit reached:",
     "context overflow:",
+    "output truncated:",
 )
 
 

--- a/src/opencollab_eval/generation/gen_prediction_workflow.py
+++ b/src/opencollab_eval/generation/gen_prediction_workflow.py
@@ -99,6 +99,7 @@ _CONTROLLED_STOP_REASON_PREFIXES = (
     "budget exceeded after model call:",
     "budget exhausted before model call:",
     "team budget exceeded:",
+    "budget reserve exhausted:",
     "step limit reached:",
     "context overflow:",
     "output truncated:",

--- a/tests/test_evaluator_public_runtime.py
+++ b/tests/test_evaluator_public_runtime.py
@@ -185,6 +185,7 @@ def test_failed_or_uncontrolled_agent_result_keeps_patch_but_blocks_submission(
         "budget exceeded after model call: 100 tokens used",
         "budget exhausted before model call: no output headroom",
         "team budget exceeded: aggregate spend reached the global cap",
+        "budget reserve exhausted: protected commit turn already used",
         "step limit reached: 4 steps",
         "context overflow: prompt exceeds the model context window",
         "output truncated: provider reached its generation limit",

--- a/tests/test_evaluator_public_runtime.py
+++ b/tests/test_evaluator_public_runtime.py
@@ -187,6 +187,7 @@ def test_failed_or_uncontrolled_agent_result_keeps_patch_but_blocks_submission(
         "team budget exceeded: aggregate spend reached the global cap",
         "step limit reached: 4 steps",
         "context overflow: prompt exceeds the model context window",
+        "output truncated: provider reached its generation limit",
         "timeout",
     ],
 )
@@ -231,13 +232,20 @@ def test_controlled_stop_keeps_quiescent_patch_and_metrics_eligible(
     assert result.submission_eligible is True
 
 
-def test_nonquiescent_controlled_stop_blocks_submission(monkeypatch, tmp_path):
+@pytest.mark.parametrize(
+    "reason",
+    [
+        "timeout",
+        "output truncated: provider reached its generation limit",
+    ],
+)
+def test_nonquiescent_controlled_stop_blocks_submission(monkeypatch, tmp_path, reason):
     class Client:
         async def agent(self, _prompt, **_kwargs):
             return RunResult(
                 output=None,
                 status="stopped",
-                reason="timeout",
+                reason=reason,
                 tokens=13,
                 metrics={"steps": 6, "execution_quiesced": False},
             )
@@ -260,7 +268,7 @@ def test_nonquiescent_controlled_stop_blocks_submission(monkeypatch, tmp_path):
     assert result.patch == ""
     assert result.patch_produced is False
     assert result.runtime_status == "stopped"
-    assert result.runtime_reason == "timeout"
+    assert result.runtime_reason == reason
     assert result.tokens_used == 13
     assert result.steps == 6
     assert result.execution_quiesced is False
@@ -278,6 +286,7 @@ def test_nonquiescent_controlled_stop_blocks_submission(monkeypatch, tmp_path):
         "team budget exceeded: aggregate spend reached the global cap",
         "step limit reached: 4 steps",
         "context overflow: prompt exceeds the model context window",
+        "output truncated: provider reached its generation limit",
         "timeout",
     ],
 )

--- a/tests/test_gen_prediction_agent_probe_eligibility.py
+++ b/tests/test_gen_prediction_agent_probe_eligibility.py
@@ -62,6 +62,7 @@ def test_failed_result_remains_ineligible_even_when_session_is_quiescent() -> No
         "team budget exceeded: aggregate spend reached the global cap",
         "step limit reached: 4 steps",
         "context overflow: prompt exceeds the model context window",
+        "output truncated: provider reached its generation limit",
     ],
 )
 def test_verbose_controlled_stop_reason_stays_diagnostic_until_proof(

--- a/tests/test_gen_prediction_agent_probe_eligibility.py
+++ b/tests/test_gen_prediction_agent_probe_eligibility.py
@@ -60,6 +60,7 @@ def test_failed_result_remains_ineligible_even_when_session_is_quiescent() -> No
         "budget exceeded after model call: 100 tokens used",
         "budget exhausted before model call: conservative input reservation",
         "team budget exceeded: aggregate spend reached the global cap",
+        "budget reserve exhausted: protected commit turn already used",
         "step limit reached: 4 steps",
         "context overflow: prompt exceeds the model context window",
         "output truncated: provider reached its generation limit",

--- a/tests/test_gen_prediction_controlled_stop.py
+++ b/tests/test_gen_prediction_controlled_stop.py
@@ -13,6 +13,7 @@ from opencollab_eval.generation import gen_prediction_safe_output as safe_output
         "budget exceeded after model call: 100 tokens used",
         "budget exhausted before model call: no output headroom",
         "team budget exceeded: aggregate spend reached the global cap",
+        "budget reserve exhausted: protected commit turn already used",
         "step_limit_exceeded",
         "step limit reached: 4 steps",
         "context_overflow",

--- a/tests/test_gen_prediction_controlled_stop.py
+++ b/tests/test_gen_prediction_controlled_stop.py
@@ -17,6 +17,7 @@ from opencollab_eval.generation import gen_prediction_safe_output as safe_output
         "step limit reached: 4 steps",
         "context_overflow",
         "context overflow: prompt exceeds the model context window",
+        "output truncated: provider reached its generation limit",
     ],
 )
 def test_trusted_controlled_stop_patch_uses_timeout_contract(
@@ -51,8 +52,16 @@ def test_trusted_controlled_stop_patch_uses_timeout_contract(
     assert safe_output.metrics_have_completed_identity(metric, patch)
 
 
+@pytest.mark.parametrize(
+    "reason",
+    [
+        "budget exceeded: 100 tokens used",
+        "output truncated: provider reached its generation limit",
+    ],
+)
 def test_empty_controlled_stop_patch_remains_ineligible(
     monkeypatch: pytest.MonkeyPatch,
+    reason: str,
 ) -> None:
     monkeypatch.setattr(
         safe_output,
@@ -60,7 +69,7 @@ def test_empty_controlled_stop_patch_remains_ineligible(
         lambda metrics, candidate: True,
     )
     metrics = {
-        "workflow_status": "budget exceeded: 100 tokens used",
+        "workflow_status": reason,
         "execution_quiesced": True,
         "submission_eligible": True,
     }
@@ -72,7 +81,7 @@ def test_empty_controlled_stop_patch_remains_ineligible(
         patch_extraction_succeeded=True,
     )
 
-    assert metrics["workflow_status"] == "budget exceeded: 100 tokens used"
+    assert metrics["workflow_status"] == reason
     assert metrics["submission_eligible"] is False
 
 

--- a/tests/test_gen_prediction_workflow_generation.py
+++ b/tests/test_gen_prediction_workflow_generation.py
@@ -669,7 +669,8 @@ def test_workflow_status_does_not_relabel_provider_failure_as_timeout_patch():
 @pytest.mark.parametrize(
     "reason",
     ["budget_exceeded", "context_overflow", "step_limit_exceeded",
-     "budget exceeded: 123 tokens used", "budget exceeded after model call: 123 tokens used"],
+     "budget exceeded: 123 tokens used", "budget exceeded after model call: 123 tokens used",
+     "output truncated: provider reached its generation limit"],
 )
 def test_workflow_status_maps_controlled_stop_patch_to_timeout_contract(reason):
     patch = "diff --git a/pkg/a.py b/pkg/a.py\n+fixed\n"

--- a/tests/test_gen_prediction_workflow_generation.py
+++ b/tests/test_gen_prediction_workflow_generation.py
@@ -670,6 +670,7 @@ def test_workflow_status_does_not_relabel_provider_failure_as_timeout_patch():
     "reason",
     ["budget_exceeded", "context_overflow", "step_limit_exceeded",
      "budget exceeded: 123 tokens used", "budget exceeded after model call: 123 tokens used",
+     "budget reserve exhausted: protected commit turn already used",
      "output truncated: provider reached its generation limit"],
 )
 def test_workflow_status_maps_controlled_stop_patch_to_timeout_contract(reason):

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -19,7 +19,7 @@ def test_release_metadata_keeps_versions_aligned_and_includes_license() -> None:
     license_bytes = (_REPO_ROOT / "LICENSE").read_bytes()
 
     assert opencollab_eval.__version__
-    assert opencollab_eval.__version__ == "0.5.0"
+    assert opencollab_eval.__version__ == "0.5.1"
     assert 'requires = ["hatchling==1.31.0"]' in pyproject
     assert f'version = "{opencollab_eval.__version__}"' in pyproject
     assert 'dependencies = ["opencollab>=0.5.0,<0.6"]' in pyproject
@@ -55,17 +55,19 @@ def test_distribution_does_not_claim_package_wide_typing() -> None:
     assert not (_PACKAGE_ROOT / "py.typed").exists()
 
 
-def test_release_documents_bind_the_050_pair() -> None:
+def test_release_documents_bind_the_051_pair() -> None:
     changelog = (_REPO_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
     releasing = (_REPO_ROOT / "RELEASING.md").read_text(encoding="utf-8")
 
+    assert "## [0.5.1] - 2026-09-04" in changelog
     assert "## [0.5.0] - 2026-08-13" in changelog
     assert "OpenCollab 0.5.0" in changelog
     assert "963585611ad2a1d0c1fc7f4ba0043af5a3d860bb" in changelog
     assert "signed annotated tag" in releasing
     assert "verify_wheel_contract.sh" in releasing
     assert "never move a published tag" in releasing
-    assert 'rev-parse "v${release_version}^{}"' in releasing
+    assert "opencollab_release_tag=v0.5.0" in releasing
+    assert 'rev-parse "${opencollab_release_tag}^{}"' in releasing
     assert 'rev-parse HEAD' in releasing
     assert 'status --porcelain' in releasing
 

--- a/tests/test_swe_eval_status_queue.py
+++ b/tests/test_swe_eval_status_queue.py
@@ -147,6 +147,47 @@ def test_per_instance_queue_accepts_sidecar_for_exact_candidate(tmp_path):
     assert queue == []
 
 
+def test_per_instance_queue_accepts_legacy_task_id_uppercase_sidecar(tmp_path):
+    """Legacy sidecar aliases must not re-run an exact completed candidate."""
+    runner = importlib.import_module("opencollab_eval.commands.run_swebench_eval_per_instance")
+    dataset_path = tmp_path / "dataset.json"
+    predictions_path = tmp_path / "predictions.jsonl"
+    work_dir = tmp_path / "eval"
+    prediction = {
+        "instance_id": "task-1",
+        "record_id": "current-record",
+        "model_name_or_path": "model",
+        "model_patch": _patch("+current\n"),
+    }
+    dataset_path.write_text(json.dumps([{"instance_id": "task-1"}]), encoding="utf-8")
+    _write_jsonl(predictions_path, [prediction])
+    report = runner.report_path(work_dir, "run", "model", "task-1")
+    report.parent.mkdir(parents=True)
+    report.write_text(json.dumps({"task-1": {"resolved": True}}), encoding="utf-8")
+    identity = runner.prediction_identity(prediction)
+    started_at_ns = time.time_ns()
+    runner.identity_path(report).write_text(
+        json.dumps(
+            {
+                "schema": "opencollab.swe_eval_attempt.v1",
+                "task_id": "task-1",
+                "record_id": "current-record",
+                "patch_sha256": identity["patch_sha256"].upper(),
+                "started_at_ns": started_at_ns,
+                "status": "completed",
+                "pid": 0,
+                "prior_report_fingerprint": "",
+            }
+        ),
+        encoding="utf-8",
+    )
+    changed_ns = max(time.time_ns(), started_at_ns + 1)
+    os.utime(report, ns=(changed_ns, changed_ns))
+
+    assert runner.report_is_done(report, "task-1", identity) is True
+    assert runner.load_eval_queue(dataset_path, predictions_path, "run", work_dir) == []
+
+
 def test_per_instance_report_rejects_unchanged_preexisting_no_sha_report(tmp_path):
     runner = importlib.import_module("opencollab_eval.commands.run_swebench_eval_per_instance")
     report = tmp_path / "report.json"


### PR DESCRIPTION
## Release candidate\n\n- Candidate commit: 9840dc4e4569eab546f6eac3fa9b7fc9d3195aa6\n- Version metadata, changelog, migration/release docs, and wheel metadata are aligned at 0.5.1.\n- Compatibility: this release requires OpenCollab >=0.5.0,<0.6 and is paired with published OpenCollab v0.5.0 (peeled SHA 963585611ad2a1d0c1fc7f4ba0043af5a3d860bb); it is not an OpenCollab 0.6.0 pairing.\n- Validation: full local suite 3137 passed, 16 skipped; release/publication tests 12 passed; paired wheel contract 3079 passed, 26 skipped; ruff, compileall, diff check, and twine check passed.\n- No model or paid calls were used.\n\nPlease run the repository CI matrix and merge only after all checks pass.