### PR TITLE
docs(release): 补充发布标题检查规则

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -9,6 +9,8 @@ OpenCollab-Eval releases are paired with a verified OpenCollab release. PyPI pub
 - Bind CI to the immutable commit behind the compatible OpenCollab tag.
 - Verify every GitHub check, test, and artifact against the exact release SHA.
 - Push only the intended tag ref and never move a published tag.
+- Use a PR and merge title that satisfies the repository's Conventional Title
+  checker, including its required Chinese summary text.
 - Use a signed annotated tag. When signing or tag protection is unavailable, record the maintainer's explicit waiver in the GitHub Release before completion.
 
 ## Verify the candidate


### PR DESCRIPTION
## Release gate follow-up

The post-merge push check rejected merge commit 2f515e88918aa64c8262bd8f95e2998c2e1e718c because the repository title checker requires Chinese summary text. This minimal documentation change records that requirement for future release PRs and does not alter runtime behavior.

- Candidate parent: 2f515e88918aa64c8262bd8f95e2998c2e1e718c
- Validation: release metadata test passed (6 tests); diff check passed.
- No model or paid calls were used.

Please run all repository checks before merging.