### PR TITLE
docs(release): 补充合并提交标题规则

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -9,8 +9,8 @@ OpenCollab-Eval releases are paired with a verified OpenCollab release. PyPI pub
 - Bind CI to the immutable commit behind the compatible OpenCollab tag.
 - Verify every GitHub check, test, and artifact against the exact release SHA.
 - Push only the intended tag ref and never move a published tag.
-- Use a PR and merge title that satisfies the repository's Conventional Title
-  checker, including its required Chinese summary text.
+- Use a PR and merge-commit title that satisfies the repository's Conventional
+  Title checker, including its required Chinese summary text.
 - Use a signed annotated tag. When signing or tag protection is unavailable, record the maintainer's explicit waiver in the GitHub Release before completion.
 
 ## Verify the candidate


### PR DESCRIPTION
## Release gate follow-up\n\nThe first post-merge check showed that the push workflow validates the full title of every commit, including the merge commit. This minimal wording correction records that requirement precisely.\n\n- Candidate head: bbc6bef\n- Parent: 2ace5420453ef12d048909be28859c54e3f94388\n- Runtime behavior and package metadata are unchanged.\n- Release metadata test: 6 passed; diff check passed.\n- No model or paid calls were used.\n\nPlease merge with the Conventional Commit subject docs(release): 补充合并提交标题规则 after all checks pass.